### PR TITLE
update Discord links to https://chat.safe.global

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Safe ecosystem is growing with 30+ teams bringing smart contract accounts to
 
 <figure><img src=".gitbook/assets/Xnapper-2022-12-01-12.29.28.png" alt=""><figcaption></figcaption></figure>
 
-If you have any questions, just reach out on our [Discord](https://discord.gg/AjG7AQD9Qn), or look through our [hackathon guide](https://www.notion.so/Safe-Hackathon-Success-Guide-53d2fb3c29424b58b1c4407519a54930) for mode ideas on what we’d like to see built.
+If you have any questions, just reach out on our [Discord](https://chat.safe.global), or look through our [hackathon guide](https://www.notion.so/Safe-Hackathon-Success-Guide-53d2fb3c29424b58b1c4407519a54930) for mode ideas on what we’d like to see built.
 
 📚 **Learning Materials:**
 

--- a/build/projects-building-with-the-gnosis-safe.md
+++ b/build/projects-building-with-the-gnosis-safe.md
@@ -29,5 +29,5 @@ Hackathon projects:
 * [https://devpost.com/software/multy](https://devpost.com/software/multy)
 * [https://devpost.com/software/peerduck](https://devpost.com/software/peerduck)
 
-If you know of any projects missing on this list, [please let us know](https://discordapp.com/invite/FPMRAwK).
+If you know of any projects missing on this list, [please let us know](https://chat.safe.global).
 

--- a/build/sdks/safe-apps/releasing-your-safe-app.md
+++ b/build/sdks/safe-apps/releasing-your-safe-app.md
@@ -56,4 +56,4 @@ Alternatively, you can provide us with the ABIs as JSON files or the links to th
 
 After we have reviewed and integrated your Safe App, the App will first be available in the [staging environment](https://safe-web-core.staging.5afe.dev) of the Safe for you to do a final review. We would then approach you to coordinate the launch and a joint announcement.
 
-At any point after the launch, if you or your users encounter issues with the Safe App, or you want to release an update to an existing Safe App, please get in touch with us via [Discord](https://discord.gg/M9uSSkng6S).
+At any point after the launch, if you or your users encounter issues with the Safe App, or you want to release an update to an existing Safe App, please get in touch with us via [Discord](https://chat.safe.global).

--- a/contracts/gnosis-safe-on-other-evm-based-networks.md
+++ b/contracts/gnosis-safe-on-other-evm-based-networks.md
@@ -24,4 +24,4 @@ The Safe team does not have the capacity to spin up and maintain full frontend a
 
 To add another supported network to the [safe-deployments repository](https://github.com/gnosis/safe-deployments) follow the steps outlined in the [safe-contracts repository](https://github.com/gnosis/safe-contracts/blob/v1.3.0/README.md#deployments).
 
-Please let us know about any questions at [safe@gnosis.io](mailto:safe@gnosis.io) or via our [Discord](https://discord.gg/FPMRAwK).
+Please let us know about any questions at [safe@gnosis.io](mailto:safe@gnosis.io) or via our [Discord](https://chat.safe.global).

--- a/security/bug-bounty-program.md
+++ b/security/bug-bounty-program.md
@@ -104,7 +104,7 @@ _We ask that:_
 
 Public disclosure of the bug or the indication of an intention to exploit it on Mainnet will make the report ineligible for a bounty. If in doubt about other aspects of the bounty, most of the [Ethereum Foundation bug bounty program rules](https://bounty.ethereum.org) will apply here.
 
-Any questions? Reach us via email ([bounty@safe.global](mailto:bounty@safe.global)) or [Discord](https://chat.gnosis-safe.io). For more information on the Safe, check out our [website](https://gnosis-safe.io) and our [Github](https://github.com/gnosis?q=safe).
+Any questions? Reach us via email ([bounty@safe.global](mailto:bounty@safe.global)) or [Discord](https://chat.safe.global). For more information on the Safe, check out our [website](https://gnosis-safe.io) and our [Github](https://github.com/gnosis?q=safe).
 
 _Happy hunting!_
 

--- a/tutorials/batch-transactions-safe-app.md
+++ b/tutorials/batch-transactions-safe-app.md
@@ -18,4 +18,4 @@ We'll assume that you are familiar with TypeScript (JavaScript), React, and Ethe
 
 ### Help
 
-If you need help, you can reach Gnosis Safe developers in the #safe-developers channel in [https://chat.gnosis.io/](https://chat.gnosis.io) or create a discussion in [https://github.com/gnosis/safe-apps-sdk/discussions](https://github.com/gnosis/safe-apps-sdk/discussions).
+If you need help, you can reach Gnosis Safe developers in the #safe-developers channel in [https://chat.safe.global](https://chat.gnosis.io) or create a discussion in [https://github.com/gnosis/safe-apps-sdk/discussions](https://github.com/gnosis/safe-apps-sdk/discussions).


### PR DESCRIPTION
Note: https://chat.safe.global redirects to https://discord.gg/nrQVY2566v

`curl https://chat.safe.global --head`

![Screen Shot 2023-01-04 at 3 11 18 PM](https://user-images.githubusercontent.com/9806858/210641108-56bbf36e-ae48-45dc-9d5d-3734bc51d694.png)

