### PR TITLE
docs: Add sample apps and integrations to Built on Safe page

### DIFF
--- a/discover/built-on-safe.md
+++ b/discover/built-on-safe.md
@@ -8,6 +8,139 @@ If you know any projects missing on this list, please let us know [on Discord](h
 
 ![Fnt1noBacAAh5X6](https://user-images.githubusercontent.com/9806858/234247416-fe59daaa-472e-4217-8b2b-f9abb43add61.jpg)
 
+## Adoption and integrations
+
+*See [safe.global](https://safe.global) > Trusted by the best*
+- 1inch
+- Aave
+- Balancer
+- Energy Web
+- Ethereum Name Service (ENS)
+- Maker
+- MetaMask
+- Open Zeppelin
+- Synthetix
+- Yearn
+- etc.
+
+## Sample apps
+
+*This is not an exhaustive list.*
+
+### Sign-in with Safe
+
+#### SSX (Self-Sovereign Anything)
+
+- About
+    - Individual signers login on behalf of individual/team/DAO Safes
+    - Site: [spruceid.com/ssx](https://spruceid.com/ssx)
+- Built by Spruce
+    - Site: [spruceid.com](https://spruceid.com)
+    - Twitter: [@SpruceID](https://twitter.com/spruceid)
+- Similar to Sign-In with Ethereum (SIWE)
+    - Twitter: [@signinwitheth](https://twitter.com/signinwitheth)
+- Blog: [blog.spruceid.com/author/spruce](https://blog.spruceid.com/author/spruce)
+
+### Coordination
+
+#### den
+
+- About: Coordination for teams
+- Site: [onchainden.com](https://www.onchainden.com)
+- Twitter: [@OnChainDen](https://twitter.com/OnChainDen)
+- Origin story: [@IttaiSvidler Tweet 2023-01-17](https://twitter.com/IttaiSvidler/status/1615364681157468163)
+- Product
+    - Open beta 2023-01-17
+    - Custom contract/token allowance approvals
+- Adoption
+    - Lido
+    - PleasrDAO
+    - OlympusDAO
+- Investors
+    - IDEO CoLab Ventures
+    - Gnosis
+    - Balaji Srinivasan
+    - etc.
+- Resources
+    - [Den Raises $2.8M to Help Teams Execute Onchain Transactions 10X Faster](https://www.onchainden.com/blog/fundraise) *by Den 2023-02-23*
+    - [Crypto Wallet Startup Den Gets $2.8M in Seed Funding Led by IDEO CoLab Ventures](https://www.coindesk.com/business/2023/02/22/crypto-wallet-startup-den-gets-28m-in-seed-funding-led-by-ideo-colab-ventures/) *by CoinDesk 2023-02-23*
+
+#### Firm
+
+- About: Coordination for teams
+- Site: [firm.org](https://firm.org/)
+- Twitter: [@firm](https://twitter.com/firm)
+
+#### Karma
+
+- About: User analytics for DAOs
+- Site: [showkarma.xyz](https://www.showkarma.xyz/)
+- Twitter: [@karmahq_](https://twitter.com/karmahq_)
+
+#### Metropolis
+
+- About
+    - Explorer for account access controls
+    - Manager role for adding and removing other signer accounts
+- Site: [pod.xyz](https://pod.xyz)
+- Twitter: [0xMetropolis](https://twitter.com/0xMetropolis)
+
+#### Multis
+
+- About
+    - Checking accounts, corporate cards, and crypto access
+    - Offramp assets to bank accounts
+        - Powered by [bridge.xyz](https://www.bridge.xyz)
+- Site: [multis.co](https://multis.co)
+- Twitter: [@multisHQ](https://twitter.com/multishq)
+- Opportunity: ...
+
+#### Screen
+
+- About: Optional custodial recovery and fraud detection
+- Site: [screenprotocol.io](https://screenprotocol.io)
+- Twitter: [@screenprotocol](https://twitter.com/screenprotocol)
+
+#### Tally
+
+- About: On-chain governance, e.g., voting, spending, and permissioning
+- Site: [tally.xyz](https://www.tally.xyz)
+    - [Types of DAOs](https://www.tally.xyz/add-a-dao)
+- Twitter: [@tallyxyz](https://twitter.com/tallyxyz)
+- ERC20 token or an NFT for membership and voting power
+
+#### Utopia Labs
+
+- Site: [utopialabs.com](https://www.utopialabs.com/)
+- Twitter: [@utopialabs_](https://twitter.com/utopialabs_)
+- Investor: Paradigm
+    - [paradigm.xyz/portfolio](https://www.paradigm.xyz/portfolio)
+- Related topics
+    - Utopia was used to raise funds for Ukraine in the initial days of the Russian 2022 invasion
+        - [UkraineDAO Raises $7M and Builds Global Network of Supporters, Says Co-Founder Alona](https://thedefiant.io/ukrainedao-fundraising-7m) *by The Defiant 2022-03-02*
+        - [NFT backed by Pussy Riot member raises $6.7 million for Ukraine](https://www.cnn.com/style/article/ukrainedao-pussy-riot-nft-flag-war-fundraising/index.html) *by CNN 2022-03-02*
+        - [@Ukraine_DAO Tweet 2022-06-25](https://twitter.com/Ukraine_DAO/status/1540845735297572864)
+
+### Messaging tools
+
+#### NinDAO
+
+- About: Create a safe from a Telegram chat.
+- Site: [nindao.xyz](https://nindao.xyz)
+- Twitter: [@nindao_bot](https://twitter.com/nindao_bot)
+- Built by Daoism Systems
+    - Site: [daoism.systems](https://daoism.systems)
+
+### Tax and accounting
+
+#### Bitwave
+
+- About: Tax and accounting for teams
+- Site: [bitwave.io](https://www.bitwave.io)
+- Twitter: [@BitwavePlatform](https://twitter.com/bitwaveplatform)
+- Adoption: Opensea, Compound, and Polygon 
+- *See [Bitwave raises $15 million for crypto-focused tax and accounting platform](https://www.theblock.co/post/192648/bitwave-raises-15-million-for-crypto-focused-tax-and-accounting-platform) by The Block 2022-12-06*
+
 ## [Hackathon Winners](https://safe-global.notion.site/6b4fe0e6c2bc49cb9c19f24d00ac02c0?v=29b399efc934443e874fba70175f8630)
 
 ![safe-hackathon-winners](https://user-images.githubusercontent.com/9806858/234252894-5f5d1f32-f773-4f2d-9d87-da221447f645.gif)


### PR DESCRIPTION
Merge the Safe open info Apps page [1] and Adoption and integrations section [2] into the Safe docs and remove the existing Safe open info Apps page and section once merged.

[1]: https://hackmd.io/@safe/oi/https%3A%2F%2Fhackmd.io%2F%40safe%2Fapps
[2]: https://hackmd.io/@safe/oi/https%3A%2F%2Fhackmd.io%2F%40safe%2Fabout#Adoption-and-integrations