### PR TITLE
fix: error in code snippet

### DIFF
--- a/safe-core-sdk/protocol-kit/reference/migrating/v2.md
+++ b/safe-core-sdk/protocol-kit/reference/migrating/v2.md
@@ -46,5 +46,8 @@ const options = {
   nonce: '',
   safeTxGas: ''
 }
-const safeTransaction = protocolKit.createTransaction({ [safeTransactionData], options })
+const safeTransaction = protocolKit.createTransaction({
+  transactions: [safeTransactionData],
+  options
+})
 ```


### PR DESCRIPTION
## Overview

We found a small error in a code snippet that can lead developers to have trouble migrating to `protocol-kit` v2