### PR TITLE
Replace Goerli with Sepolia

### DIFF
--- a/pages/api-service-architecture.md
+++ b/pages/api-service-architecture.md
@@ -17,7 +17,7 @@ Safe's production setup is a mixture of several instances of the Safe Transactio
 
 ## Safe Transaction Service
 
-The Transaction Service uses tracing in Mainnet/Goerli and Gnosis Chain and event indexing in other chains to keep track of transactions related to Safe contracts. One instance of the Transaction Service runs per supported network (Mainnet, Goerli, Gnosis Chain, Polygon, etc.).
+The Transaction Service uses tracing in Mainnet/Sepolia and Gnosis Chain and event indexing in other chains to keep track of transactions related to Safe contracts. One instance of the Transaction Service runs per supported network (Mainnet, Sepolia, Gnosis Chain, Polygon, etc.).
 
 ## Safe Config Service
 

--- a/pages/api-service-architecture/safe-transaction-service.mdx
+++ b/pages/api-service-architecture/safe-transaction-service.mdx
@@ -93,7 +93,7 @@ The following example shows how to get a `safe_tx_hash` with [`safe-eth-py`](htt
 ```python
 from gnosis.safe.safe_tx import SafeTx
 from gnosis.eth.ethereum_client import EthereumClient
-eth_client = EthereumClient("https://rpc.goerli.eth.gateway.fm")
+eth_client = EthereumClient("https://sepolia.gateway.tenderly.co")
 safe_tx = SafeTx(eth_client, "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C", "0xc6b82bA149CFA113f8f48d5E3b1F78e933e16DfD",10000000000000000,"",0,0,0,0,"0x0000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000", safe_nonce=206)
 print(safe_tx.safe_tx_hash.hex())
 ```
@@ -144,7 +144,7 @@ message = "Hello SafeMessages"
 # Hash EIP-191
 message_hash = defunct_hash_message(text=message)
 # get message hash from safe
-eth_client = EthereumClient("https://rpc.goerli.eth.gateway.fm")
+eth_client = EthereumClient("https://sepolia.gateway.tenderly.co")
 safe_address = "TheAliceAndBobSafeAddress"
 safe = Safe(safe_address, eth_client)
 safe_message_hash = safe.get_message_hash(message_hash)
@@ -159,10 +159,10 @@ body = {
     "safeAppId": 0,
     "signature": signature_alice.signature.hex()
 }
-requests.post(f'https://safe-transaction-goerli.safe.global/api/v1/safes/{safe_address}/messages/',json=body)
+requests.post(f'https://safe-transaction-sepolia.safe.global/api/v1/safes/{safe_address}/messages/',json=body)
 
 # Message was created, let's request by message hash
-response =  requests.get(f'https://safe-transaction-goerli.safe.global/api/v1/messages/{safe_message_hash.hex()}/')
+response =  requests.get(f'https://safe-transaction-sepolia.safe.global/api/v1/messages/{safe_message_hash.hex()}/')
 print(response.json())
 
 # Adding Bob confirmation
@@ -173,7 +173,7 @@ signature_bob = bob.signHash(safe_message_hash)
 body = {
     "signature": signature_bob.signature.hex()
 }
-requests.post(f'https://safe-transaction-goerli.safe.global/api/v1/messages/{safe_message_hash.hex()}/signatures/',json=body)
+requests.post(f'https://safe-transaction-sepolia.safe.global/api/v1/messages/{safe_message_hash.hex()}/signatures/',json=body)
 
 ```
 
@@ -197,7 +197,7 @@ Supported and configured networks on `safe-eth-py`:
 **Example transaction decoder**
 ```bash
 curl -X 'POST' \
-  'https://safe-transaction-goerli.safe.global/api/v1/data-decoder/' \
+  'https://safe-transaction-sepolia.safe.global/api/v1/data-decoder/' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'X-CSRFToken: Gx1aRa8kIJGIAfReLAWwr9Q6dHv22dFt7VprdipLryHcxpfhk9aV0UDAhNz8gGYz' \

--- a/pages/api-service-architecture/safe-transaction-service.mdx
+++ b/pages/api-service-architecture/safe-transaction-service.mdx
@@ -89,7 +89,7 @@ sequenceDiagram
 `keccak256(0x19 || 0x1 || domainSeparator || safeTxHashStruct)`  
 where `safeTxHashStruct` is the `hashStruct` of a Safe transaction.
 
-The following example shows how to get a `safe_tx_hash` with [`safe-eth-py`](https://pypi.org/project/safe-eth-py/) with the parameter of the next transaction [0x34ae46cf7d884309a438a7e9a3161fa05dfc5068681ac3877a947971af845a18](https://safe-transaction-goerli.safe.global/api/v1/multisig-transactions/0x34ae46cf7d884309a438a7e9a3161fa05dfc5068681ac3877a947971af845a18/)
+The following example shows how to get a `safe_tx_hash` with [`safe-eth-py`](https://pypi.org/project/safe-eth-py/)
 ```python
 from gnosis.safe.safe_tx import SafeTx
 from gnosis.eth.ethereum_client import EthereumClient

--- a/pages/api-supported-networks.md
+++ b/pages/api-supported-networks.md
@@ -12,14 +12,13 @@ description: This page provides an overview of the available services
 | Aurora                       | [https://safe-transaction-aurora.safe.global](https://safe-transaction-aurora.safe.global/)              |
 | Avalanche                    | [https://safe-transaction-avalanche.safe.global](https://safe-transaction-avalanche.safe.global/)        |
 | Base                         | [https://safe-transaction-base.safe.global](https://safe-transaction-base.safe.global)                   |
-| Base Goerli                  | [https://safe-transaction-base-testnet.safe.global](https://safe-transaction-base-testnet.safe.global/)  |
+<!-- TO DO: Add Base Sepolia when ready in prod -->
 | BNB Smart Chain              | [https://safe-transaction-bsc.safe.global](https://safe-transaction-bsc.safe.global/)                    |
 | Celo                         | [https://safe-transaction-celo.safe.global](https://safe-transaction-celo.safe.global/)                  |
 | Ethereum Mainnet             | [https://safe-transaction-mainnet.safe.global](https://safe-transaction-mainnet.safe.global/)            |
 | Gnosis Chain                 | [https://safe-transaction-gnosis-chain.safe.global](https://safe-transaction-gnosis-chain.safe.global/)  |
-| Goerli                       | [https://safe-transaction-goerli.safe.global](https://safe-transaction-goerli.safe.global/)              |
-| Sepolia                      | [https://safe-transaction-sepolia.safe.global](https://safe-transaction-sepolia.safe.global/)            |
 | Optimism                     | [https://safe-transaction-optimism.safe.global](https://safe-transaction-optimism.safe.global/)          |
 | Polygon                      | [https://safe-transaction-polygon.safe.global](https://safe-transaction-polygon.safe.global/)            |
 | Polygon zkEVM                | [https://safe-transaction-zkevm.safe.global](https://safe-transaction-zkevm.safe.global/)                |
+| Sepolia                      | [https://safe-transaction-sepolia.safe.global](https://safe-transaction-sepolia.safe.global/)            |
 | zkSync Era Mainnet           | [https://safe-transaction-zksync.safe.global](https://safe-transaction-zksync.safe.global/)              |

--- a/pages/apps-sdk-release.mdx
+++ b/pages/apps-sdk-release.mdx
@@ -67,7 +67,7 @@ After we've reviewed and integrated your Safe App, the App will first be availab
 
 At any point after the launch, if you or your users encounter issues with the Safe App or want to release an update to an existing Safe App, please contact us via [Discord](https://chat.safe.global).
 
-While developing your Safe App, you can use [our production interface](https://app.safe.global) to test it. Some testnets like Goerli are also available.
+While developing your Safe App, you can use [our production interface](https://app.safe.global) to test it. Some testnets like Sepolia are also available.
 
 Once your app is live, even if you run it locally, you can import it to the Safe application as a custom app. To do so, you should select the "Apps" tab:
 

--- a/pages/sdk-auth-kit/guides/safe-auth.md
+++ b/pages/sdk-auth-kit/guides/safe-auth.md
@@ -23,7 +23,7 @@ Create an instance of the [SafeAuthPack](https://github.com/safe-global/safe-cor
 > Supported networks:
 >
 > - Production: Ethereum, Polygon, BSC, Avalanche, Optimism, Celo, Arbitrum, Gnosis chain
-> - Test: Goerli, Sepolia, Polygon Mumbai, BSC Testnet, Avalanche Testnet, Arbitrum Testnet, Optimism Testnet
+> - Test: Sepolia, Polygon Mumbai, BSC Testnet, Avalanche Testnet, Arbitrum Testnet, Optimism Testnet
 ```typescript
 import {
   SafeAuthPack,

--- a/pages/sdk-auth-kit/reference/safe-auth-pack.md
+++ b/pages/sdk-auth-kit/reference/safe-auth-pack.md
@@ -93,7 +93,7 @@ safeAuthInitOptions {
 
 - The list of supported chains is:
   - Production: Ethereum, Polygon, BSC, Avalanche, Optimism, Celo, Arbitrum, Gnosis chain.
-  - Test: Goerli, Sepolia, Polygon Mumbai, BSC Testnet, Avalanche Testnet, Arbitrum Testnet, Optimism Testnet.
+  - Test: Sepolia, Polygon Mumbai, BSC Testnet, Avalanche Testnet, Arbitrum Testnet, Optimism Testnet.
 - Call always the `init()` method before interacting with the other methods in the pack.
 - The `init()` method creates an iframe and establishes a connection with the embedded wallet domain. To remove the iframe and disconnect the connection, use the `signOut()` method. If you want to sign out and sign in again in a single-page application (SPA) fashion, avoid using `signOut({ reset: true })` as it will clean up the session, iframe, and connection. Instead, you will need to re-instantiate the pack.
 

--- a/pages/sdk-protocol-kit.md
+++ b/pages/sdk-protocol-kit.md
@@ -62,7 +62,7 @@ The signers trigger transactions to the Ethereum blockchain or off-chain transac
 
 You can get a public RPC URL from [Chainlist](https://chainlist.org), however, public RPC URLs can be unreliable so you can also try a dedicated provider like Infura or Alchemy.
 
-For this tutorial, we will be creating a Safe on the Goerli Testnet.
+For this tutorial, we will be creating a Safe on the Sepolia Testnet.
 
 ```tsx
 import { ethers } from 'ethers'
@@ -71,8 +71,8 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-// https://chainlist.org/?search=goerli&testnets=true
-const RPC_URL='https://eth-goerli.public.blastapi.io'
+// https://chainlist.org/?search=sepolia&testnets=true
+const RPC_URL='https://eth-sepolia.public.blastapi.io'
 const provider = new ethers.JsonRpcProvider(RPC_URL)
 
 // Initialize signers
@@ -90,7 +90,7 @@ const ethAdapterOwner1 = new EthersAdapter({
 
 The [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit) consumes the [Safe Transaction Service API](https://github.com/safe-global/safe-transaction-service). To use this library, create a new instance of the `SafeApiKit` class, imported from `@safe-global/api-kit`. In chains where Safe provides a Transaction Service, it's enough to specify the `chainId.` You can specify your own service using the optional `txServiceUrl` parameter.
 
-You will be using Goerli for this tutorial, however, you can also get [service URLs for different networks](./api-supported-networks.md).
+You will be using Sepolia for this tutorial, however, you can also get [service URLs for different networks](./api-supported-networks.md).
 
 ```tsx
 import SafeApiKit from '@safe-global/api-kit'
@@ -109,7 +109,7 @@ const safeApiKit = new SafeApiKit({
 
 ### Initialize the Protocol Kit
 
-Goerli is a supported network so you don't need to specify the contract addresses, however, to see how to create a safe on a local or unsupported network, see [Instantiate an EthAdapter](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md#instantiate-an-ethadapter).
+Sepolia is a supported network so you don't need to specify the contract addresses, however, to see how to create a safe on a local or unsupported network, see [Instantiate an EthAdapter](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md#instantiate-an-ethadapter).
 
 Safe Factory is used to create Safes. While Safe class represents an instance of a specific Safe account.
 
@@ -143,8 +143,8 @@ const safeSdkOwner1 = await safeFactory.deploySafe({ safeAccountConfig })
 const safeAddress = await safeSdkOwner1.getAddress()
 
 console.log('Your Safe has been deployed:')
-console.log(`https://goerli.etherscan.io/address/${safeAddress}`)
-console.log(`https://app.safe.global/gor:${safeAddress}`)
+console.log(`https://sepolia.etherscan.io/address/${safeAddress}`)
+console.log(`https://app.safe.global/sep:${safeAddress}`)
 ```
 
 ### Send ETH to the Safe
@@ -164,7 +164,7 @@ const transactionParameters = {
 const tx = await owner1Signer.sendTransaction(transactionParameters)
 
 console.log('Fundraising.')
-console.log(`Deposit Transaction: https://goerli.etherscan.io/tx/${tx.hash}`)
+console.log(`Deposit Transaction: https://sepolia.etherscan.io/tx/${tx.hash}`)
 ```
 
 ## Making a transaction from a Safe
@@ -273,7 +273,7 @@ const executeTxResponse = await safeSdk.executeTransaction(safeTransaction)
 const receipt = await executeTxResponse.transactionResponse?.wait()
 
 console.log('Transaction executed:')
-console.log(`https://goerli.etherscan.io/tx/${receipt.transactionHash}`)
+console.log(`https://sepolia.etherscan.io/tx/${receipt.transactionHash}`)
 ```
 
 ### Confirm that the transaction was executed

--- a/pages/smart-account-signatures/eip-1271.md
+++ b/pages/smart-account-signatures/eip-1271.md
@@ -123,7 +123,9 @@ const getSafeMessageHash = async (
 
 Then we can query the state of the message from the network-specific Transaction Service endpoint for messages: `https://safe-transaction-<NETWORK>.safe.global/api/v1/messages/<SAFE_MSG_HASH>`.
 
-An example message on Goerli can be found here: `https://safe-transaction-goerli.safe.global/api/v1/messages/0x7f4032fd13f27c5fce4694a1a6b79f65c68656da4eee4347a414f5bcec915b39/`.
+<!--
+An example message on Sepolia can be found here: `https://safe-transaction-goerli.safe.global/api/v1/messages/0x7f4032fd13f27c5fce4694a1a6b79f65c68656da4eee4347a414f5bcec915b39/`.
+-->
 
 For other network endpoints, see [Available Services](../../safe-core-api/supported-networks.md).
 
@@ -134,7 +136,7 @@ const fetchMessage = async (
   safeMessageHash: string
 ): Promise<TransactionServiceSafeMessage | undefined> => {
   const safeMessage = await fetch(
-    `https://safe-transaction-goerli.safe.global/api/v1/messages/${safeMessageHash}`,
+    `https://safe-transaction-sepolia.safe.global/api/v1/messages/${safeMessageHash}`,
     {
       headers: { 'Content-Type': 'application/json' }
     }


### PR DESCRIPTION
## Context
As Safe will not support Goerli testnet anymore in Safe{Wallet} and infra starting from the 1st of Feb, we are replacing all the references in our documentation in favour of Sepolia testnet.

## Dependencies (not blocking)
- [ ] Monerium is still working on supporting Sepolia, but they are still using Goerli for now on their testing env.
- [ ] Add Base Sepolia network when the Safe Transaction Service is available in prod (only available in staging for now). Line 15 in [pages/api-supported-networks.md](https://github.com/safe-global/safe-docs/compare/development...nextra-sepolia?expand=1#diff-037fcec164378fafbf0daae953e57bc24f39a76c8db11f45ad8f46d77f2812e2).