### PR TITLE
docs: Add Base Sepolia to API supported networks

### DIFF
--- a/pages/api-supported-networks.md
+++ b/pages/api-supported-networks.md
@@ -11,7 +11,8 @@ description: This page provides an overview of the available services
 | Arbitrum                     | [https://safe-transaction-arbitrum.safe.global](https://safe-transaction-arbitrum.safe.global/)          |
 | Aurora                       | [https://safe-transaction-aurora.safe.global](https://safe-transaction-aurora.safe.global/)              |
 | Avalanche                    | [https://safe-transaction-avalanche.safe.global](https://safe-transaction-avalanche.safe.global/)        |
-| Base                         | [https://safe-transaction-base.safe.global](https://safe-transaction-base.safe.global)                   |
+| Base                         | [https://safe-transaction-base.safe.global](https://safe-transaction-base.safe.global/)                  |
+| Base Sepolia                 | [https://safe-transaction-base-sepolia.safe.global](https://safe-transaction-base-sepolia.safe.global/)  |
 | BNB Smart Chain              | [https://safe-transaction-bsc.safe.global](https://safe-transaction-bsc.safe.global/)                    |
 | Celo                         | [https://safe-transaction-celo.safe.global](https://safe-transaction-celo.safe.global/)                  |
 | Ethereum Mainnet             | [https://safe-transaction-mainnet.safe.global](https://safe-transaction-mainnet.safe.global/)            |


### PR DESCRIPTION
## Context
This PR:
- Adds Base Sepolia network to the API supported networks list.
- Fixes: https://github.com/safe-global/safe-docs/issues/366