### PR TITLE
feat: Remove ETHGlobal London banner

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -45,14 +45,7 @@ const config: DocsThemeConfig = {
       {children}
       <Feedback />
     </>
-  ),
-  banner: {
-    key: 'ethglobal-london-2024',
-    text: <a href="https://ethglobal.com/events/london2024/prizes#safe" target="_blank">
-    💰 Are you hacking at ETHGlobal London? Check our bounties →
-  </a>,
-  dismissible: true
-  }
+  )
 }
 
 export default config


### PR DESCRIPTION
## Context
This PR:
- Removes the ETHGlobal London banner.


### NOTE: Do not merge until the event is over.