### PR TITLE
Add NEXT_PUBLIC_HOST_URL to production and staging environments

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -34,6 +34,7 @@ jobs:
           NEXT_PUBLIC_GOOGLE_ANALYTICS_DOMAIN: ${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS_DOMAIN }}
           NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID }}
           NEXT_PUBLIC_IS_PRODUCTION: true
+          NEXT_PUBLIC_HOST_URL: 'https://docs.safe.global'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Build app
         shell: bash
         run: pnpm build
+        env:
+          NEXT_PUBLIC_HOST_URL: 'https://docs.staging.5afe.dev'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
Fix open graph attributes by adding NEXT_PUBLIC_HOST_URL .env variable in deployment scripts