### PR TITLE
chore: Add support for readability on mdx files

### DIFF
--- a/.github/workflows/report-readability.yml
+++ b/.github/workflows/report-readability.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: Rebilly/lexi@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  glob: '**/*.md'
+                  glob: '**/*.{md,mdx}'


### PR DESCRIPTION
## Context
Readability checks not working on `.mdx` files.

It looks it's supported: https://github.com/Rebilly/lexi/blob/628628c29fa840a6497a4bcf0c3aa2012fc74d1d/src/cli/report.ts#L14-L17

This PR:
- Updates the value of the `GLOB` variable to support `.mdx` files.

Note:
- This PR is not tested.