### PR TITLE
docs: Replace RelayKit alpha version with latest

### DIFF
--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -16,7 +16,7 @@ Read the [Safe4337Module documentation](../../../home/4337-safe) to understand i
 ## Install dependencies
 
 ```bash
-yarn add ethers @safe-global/protocol-kit @safe-global/relay-kit@alpha
+yarn add ethers @safe-global/protocol-kit @safe-global/relay-kit
 ```
 
 ## Steps

--- a/pages/sdk/relay-kit/reference/safe-4337-pack.mdx
+++ b/pages/sdk/relay-kit/reference/safe-4337-pack.mdx
@@ -9,7 +9,7 @@ The `Safe4337Pack` enables Safe accounts to interact with user operations throug
 To use `Safe4337Pack` in your project, start by installing the `relay-kit` package with this command:
 
 ```bash
-yarn add @safe-global/relay-kit@alpha
+yarn add @safe-global/relay-kit
 ```
 
 ## Reference


### PR DESCRIPTION
## Context
This PR:
- After the release of the Relay Kit including the `Safe4337Pack`, this PR replaces the `alpha` version with the latest one.