### PR TITLE
Replace `callsOnly` by `onlyCalls` in the docs

### DIFF
--- a/pages/sdk/protocol-kit/reference/safe.md
+++ b/pages/sdk/protocol-kit/reference/safe.md
@@ -259,14 +259,14 @@ const options: SafeTransactionOptionalProps = {
 const safeTransaction = await protocolKit.createTransaction({ transactions, options })
 ```
 
-In addition, the optional `callsOnly` parameter, which is `false` by default, allows forcing the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
+In addition, the optional `onlyCalls` parameter, which is `false` by default, allows forcing the use of the `MultiSendCallOnly` instead of the `MultiSend` contract when sending a batch transaction:
 
 ```typescript
-const callsOnly = true
+const onlyCalls = true
 const safeTransaction = await protocolKit.createTransaction({
   transactions,
   options,
-  callsOnly
+  onlyCalls
 })
 ```
 


### PR DESCRIPTION
There is a mistake in the docs where `onlyCalls` should be `callsOnly`, leading to the flag to be ignored

See the code here : https://github.com/safe-global/safe-core-sdk/blob/0bc0515d4265ef099085644791d4fa1fe4e1cf55/packages/relay-kit/src/packs/gelato/GelatoRelayPack.ts#L216