### PR TITLE
fix: Add await to getPendingTransactions call

### DIFF
--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -210,7 +210,7 @@ await apiKit.proposeTransaction({
 Recall that you created the `apiKit` in [Initialize the API Kit](./#initialize-the-safe-api-kit).
 
 ```tsx
-const pendingTransactions = await apiKit.getPendingTransactions(safeAddress).results
+const pendingTransactions = (await apiKit.getPendingTransactions(safeAddress)).results
 ```
 
 ### Confirm the transaction: Second confirmation


### PR DESCRIPTION
The example for `getPendingTransactions` fails to wrap the await in such a way to return the results.  The `getPendingTransactions` function returns a promise, so it needs to be awaited in order to then pull the results.