### PR TITLE
fix: update blog urls from mirror to safe.global

### DIFF
--- a/components/ResourceHub/community-resources.json
+++ b/components/ResourceHub/community-resources.json
@@ -193,7 +193,7 @@
       "Tutorial",
       "Safe Smart Account"
     ],
-    "image": "https://2121962569-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FfkVTcYLDkf0mcGW9zUvc%2Fsocialpreview%2FjEO2ZH66FYxGI0XkXIrp%2FCover%20Image%20Twitter.png?alt=media&token=4d81d546-5eeb-487e-8759-1936f71acde9"
+    "image": "https://2121962569-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FfkVTcYLDkf0mcGW9zUvc%2Fsocialpreview%2FuVf9l9EccLGE9k7H3uUR%2FTwitter%20header%20-%207.png?alt=media&token=6ee10b06-f290-412e-acec-87dcc24c9f96"
   },
   {
     "name": "Safe Study (Japanese)",

--- a/components/ResourceHub/company-resources.json
+++ b/components/ResourceHub/company-resources.json
@@ -110,7 +110,7 @@
   },
   {
     "name": "Get the most secure web3 account in <30 seconds",
-    "url": "https://safe.mirror.xyz/pyf0meKAyooY1v8GB7z6Ik7o4wPHGTyCOcUf--UU-IA",
+    "url": "https://safe.global/blog/get-the-most-secure-web3-account-in-less-than-30-seconds",
     "type": "Blog Post",
     "date": "2023-11-13",
     "description": "Introducing self-custody for everyone. From today, you can secure your crypto fast and free with Safe{Wallet} on Gnosis Chain using just your Google Account.",
@@ -122,7 +122,7 @@
   },
   {
     "name": "The new AI agent economy will run on smart accounts",
-    "url": "https://safe.mirror.xyz/V965PykKzlE1PCuWxBjsCJR12WscLcnMxuvR9E9bP-Y",
+    "url": "https://safe.global/blog/the-new-ai-agent-economy-will-run-on-smart-accounts",
     "type": "Blog Post",
     "date": "2023-10-25",
     "description": "Web3's first billion users may not only be humans, but AI agents.",
@@ -134,7 +134,7 @@
   },
   {
     "name": "Enhancing Blockchain Security with ERC-7512: A Standard for representing smart contract audits onchain",
-    "url": "https://safe.mirror.xyz/Li4Mb4teTEmosE6dAsnJ_iz3aMKOV_4lDU84W4TSfc0",
+    "url": "https://safe.global/blog/enhancing-blockchain-security-with-erc-7512-a-standard-for-representing",
     "type": "Blog Post",
     "date": "2023-09-21",
     "description": "In a significant stride towards fortifying blockchain security, we at Safe, along with top security experts have introduced ERC-7512, a standard for onchain audit report representations.",
@@ -146,7 +146,7 @@
   },
   {
     "name": "Safe Modular Smart Account Architecture - Explained",
-    "url": "https://safe.mirror.xyz/t76RZPgEKdRmWNIbEzi75onWPeZrBrwbLRejuj-iPpQ",
+    "url": "https://safe.global/blog/safe-modular-smart-account-architecture-explained",
     "type": "Blog Post",
     "date": "2023-07-10",
     "description": "Safe is at the forefront of modular smart account infrastructure, paving the way for developers to create a diverse range of applications and wallets.",
@@ -159,7 +159,7 @@
   },
   {
     "name": "Launching Monerium on Safe{Core}: Connecting Safes to Euro IBAN accounts",
-    "url": "https://safe.mirror.xyz/4pgiJAEQ2Jt0ij9Ezc8FSOSiRSfVY4Im8FZ0LuICx-8",
+    "url": "https://safe.global/blog/launching-monerium-on-safe-core-connecting-safes-to-euro-iban-accounts",
     "type": "Blog Post",
     "date": "2023-07-06",
     "description": "Today, the Safe{Core} Account Abstraction SDK added a shiny new tool to its toolbox.",
@@ -170,7 +170,7 @@
   },
   {
     "name": "Redefine security with new Safe{Wallet} transaction risk scanner",
-    "url": "https://safe.mirror.xyz/rInLWZwD_sf7enjoFerj6FIzCYmVMGrrV8Nhg4THdwI",
+    "url": "https://safe.global/blog/redefine-security-with-new-safe-wallet-transaction-risk-scanner",
     "type": "Blog Post",
     "date": "2023-07-26",
     "description": "We're excited to bring you news of an important enhancement to your transactional security.",
@@ -182,7 +182,7 @@
   },
   {
     "name": "Safe Smart Accounts & Diamond Proxies",
-    "url": "https://safe.mirror.xyz/P83_rVQuUQJAM-SnMpWvsHlN8oLnCeSncD1txyMDqpE",
+    "url": "https://safe.global/blog/safe-smart-accounts-and-diamond-proxies",
     "type": "Blog Post",
     "date": "2023-04-25",
     "description": "Safe is a modular smart account protocol that uses Account Abstraction to build a wide range of wallets and other solutions through a shared plugin interface.",
@@ -195,7 +195,7 @@
   },
   {
     "name": "Account Abstraction in a Multichain Landscape - Part 1: Addresses",
-    "url": "https://safe.mirror.xyz/4GcGAOFno-suTCjBewiYH4k4yXPDdIukC5woO5Bjc4w",
+    "url": "https://safe.global/blog/account-abstraction-in-a-multichain-landscape-part-1-addresses",
     "type": "Blog Post",
     "date": "2023-03-22",
     "description": "This is the first article in a series of posts exploring account abstraction in a multichain landscape.",
@@ -207,7 +207,7 @@
   },
   {
     "name": "Launching Safe{Core} Account Abstraction Stack with Stripe, Gelato and Web3Auth",
-    "url": "https://safe.mirror.xyz/FLvQQ5J9qXks0izRl73oC6LiFLofbwFNorwzaEj_xL8",
+    "url": "https://safe.global/blog/launching-safe-core-account-abstraction-stack-with-stripe-gelato-and",
     "type": "Blog Post",
     "date": "2023-03-01",
     "description": "Safe is launching Safe{Core}, a modular AA stack with Stripe, Gelato, and Web3Auth as launch partners.",
@@ -219,7 +219,7 @@
   },
   {
     "name": "Take Back Ownership Manifesto",
-    "url": "https://safe.mirror.xyz/tO26nZ4CruKCS8d49pyModJhzHw1TTm2QcMqx2lYaXQ",
+    "url": "https://safe.global/blog/take-back-ownership-manifesto",
     "type": "Blog Post",
     "date": "2023-01-18",
     "description": "Not your keys, not your coins.",

--- a/components/ResourceHub/company-resources.json
+++ b/components/ResourceHub/company-resources.json
@@ -118,7 +118,7 @@
       "Tutorial",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/nft/9kHb8UBlFkKq7EMDAnFJB.png"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/4my478TXYdYPQd6oEuh5uY/739dfaef6f2c8b7b663f43f876bc5242/cover-get-the-most-secure-web3-account-in-30-seconds.png"
   },
   {
     "name": "The new AI agent economy will run on smart accounts",
@@ -130,7 +130,7 @@
       "Perspectives",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/nft/iLnq-8GT4vb6kUflMzjBn.png"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/36oTG1QP1gGwD5IC33InSf/36eb52c9c1772a2e8769e7007d24bc1b/cover-the-new-ai-agent-economy-will-run-on-smart-accounts.png"
   },
   {
     "name": "Enhancing Blockchain Security with ERC-7512: A Standard for representing smart contract audits onchain",
@@ -142,7 +142,7 @@
       "Safe Smart Account",
       "Security"
     ],
-    "image": "https://images.mirror-media.xyz/publication-images/82e06bfQvabGWD6lCEuI5.png?height=1440&width=2880"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/29E7EwzAxcr8rONnTgJSyS/c389b3abaabcd51d52a7389504a739c0/cover-enhancing-blockchain-security-with-erc-7512-a-standard-for-representing.png"
   },
   {
     "name": "Safe Modular Smart Account Architecture - Explained",
@@ -155,7 +155,7 @@
       "Account Abstraction",
       "Safe Smart Account"
     ],
-    "image": "https://images.mirror-media.xyz/nft/27RD2g-DuOqbqhvJPR2PB.jpeg"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/4OzV678C097bxt3DfLxF78/62299e96822720d071b776120d3a41d9/cover-safe-modular-smart-account-architecture-explained.jpg"
   },
   {
     "name": "Launching Monerium on Safe{Core}: Connecting Safes to Euro IBAN accounts",
@@ -166,7 +166,7 @@
     "tags": [
       "Introduction"
     ],
-    "image": "https://images.mirror-media.xyz/nft/sxVBoT7TfTZRqUvk4UN0K.png"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/2v19HE5UcMJsTcxNHw6DDi/66f51b33b536f66888c97707c89ec616/cover-launching-monerium-on-safecore-connecting-safes-to-euro-iban.png"
   },
   {
     "name": "Redefine security with new Safe{Wallet} transaction risk scanner",
@@ -178,7 +178,7 @@
       "Security",
       "Safe Wallet"
     ],
-    "image": "https://images.mirror-media.xyz/publication-images/Efdea-Sf1JbaDe93zVLTf.png?height=1000&width=1999"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/C5omzZUPw6xHpUqomo3dN/576cbccdd1171bff450c4ab8fe36ade9/cover-redefine-security-with-new-safewallet-transaction-risk-scanner.png"
   },
   {
     "name": "Safe Smart Accounts & Diamond Proxies",
@@ -191,7 +191,7 @@
       "Safe Smart Account",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/publication-images/q6Bho-3wXGhu_1pvBwMix.png?height=1440&width=2880"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/4jQL0u5YlOx8z2owaE7hSH/fcfb1b7004adf087bd91ecd9c9666bcb/cover-safe-smart-accounts-diamond-proxies.png"
   },
   {
     "name": "Account Abstraction in a Multichain Landscape - Part 1: Addresses",
@@ -203,7 +203,7 @@
       "Deep Dive",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/publication-images/Fi-Z9FwMkDU6ClXmmhCp_.png?height=1440&width=2880"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/1OretCIMqH5ywTaFvglQS0/6f22ca9ba059eb0788e91183b68c5d2c/cover-account-abstraction-in-a-multichain-landscape-part-1-addresses.png"
   },
   {
     "name": "Launching Safe{Core} Account Abstraction Stack with Stripe, Gelato and Web3Auth",
@@ -215,7 +215,7 @@
       "Introduction",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/nft/ZfRdO8WA9bCbm_tvQPWYv.png"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/2tTVVJDUi8efWXrmrzZsPU/6fac66b05bddeaa5279577199e69349d/cover-launching-safecore-account-abstraction-stack-with-stripe.png"
   },
   {
     "name": "Take Back Ownership Manifesto",
@@ -227,7 +227,7 @@
       "Perspectives",
       "Account Abstraction"
     ],
-    "image": "https://images.mirror-media.xyz/nft/8HEwVv3Onyd4Dc0QQYt0q.png"
+    "image": "https://images.ctfassets.net/1i5gc724wjeu/7FyYgDLb7NFOTsYlJTKRMm/eefcf95af684e558cebf4a70282b2c1e/cover-take-back-ownership.png"
   },
   {
     "name": "Safe Community Call #1 with Castle NFT Platform",


### PR DESCRIPTION
Update the mirror blog URLs in the Resource Hub to safe.global/blog for SEO (our blog is the main asset and all the other instances are/should be canonical links). Also, regenerated the OG metadata based on the new URLs