### PR TITLE
fix: Increase line-height in titles

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,7 +12,7 @@ h1 {
 }
 
 h2 {
-  line-height: 36px;
+  line-height: 42px;
 }
 
 h3 {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -11,6 +11,14 @@ h1 {
   line-height: 60px;
 }
 
+h2 {
+  line-height: 36px;
+}
+
+h3 {
+  line-height: 36px;
+}
+
 /* Navbar */
 #__next > div > div > div {
   backdrop-filter: blur(8px);


### PR DESCRIPTION
## Context
This PR:
- Increases the `line-height` CSS property in the `h2` and `h3` titles. This fixes the current overlap when there are multiple lines.