### PR TITLE
fix: broken links to SDK repo and remove references to guide

### DIFF
--- a/pages/sdk/_meta.json
+++ b/pages/sdk/_meta.json
@@ -8,9 +8,9 @@
     "title": "Safe{Core} SDK"
   },
   "overview": "Overview",
-  "auth-kit": "Auth Kit",
   "protocol-kit": "Protocol Kit",
-  "onramp-kit": "Onramp Kit",
+  "api-kit": "API Kit",
   "relay-kit": "Relay Kit",
-  "api-kit": "API Kit"
+  "auth-kit": "Auth Kit",
+  "onramp-kit": "Onramp Kit"
 }

--- a/pages/sdk/api-kit.mdx
+++ b/pages/sdk/api-kit.mdx
@@ -103,7 +103,7 @@ For more detailed information, see the [API Kit Reference](./api-kit/reference.m
 
   Before a transaction can be executed, any of the Safe signers needs to initiate the process by creating a proposal of a transaction. We send this transaction to the service to make it accessible by the other owners so they can give their approval and sign the transaction as well.
 
-For a full list and description of the properties see [proposeTransaction](./api-kit/reference#proposetransaction) in the API Kit reference.
+For a full list and description of the properties see [`proposeTransaction`](./api-kit/reference#proposetransaction) in the API Kit reference.
 
   ```typescript
   // Create transaction
@@ -146,7 +146,7 @@ For a full list and description of the properties see [proposeTransaction](./api
 
   ### Confirm the transaction
 
-  In this step we need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the [confirmTransaction](./api-kit/reference#confirmtransaction) method.
+  In this step we need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the [`confirmTransaction`](./api-kit/reference#confirmtransaction) method.
 
   ```typescript
   const protocolKitOwner2 = await Safe.init({

--- a/pages/sdk/api-kit.mdx
+++ b/pages/sdk/api-kit.mdx
@@ -18,7 +18,7 @@ The [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/ap
 
 In this guide we will see how to propose transactions to the service and collect the signatures from the owners so they become executable.
 
-For more detailed information, see the guide [Integrating the Protocol Kit and API Kit](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md) and the [API Kit Reference](./api-kit/reference.md).
+For more detailed information, see the [API Kit Reference](./api-kit/reference.md).
 
 ## Prerequisites
 
@@ -103,6 +103,8 @@ For more detailed information, see the guide [Integrating the Protocol Kit and A
 
   Before a transaction can be executed, any of the Safe signers needs to initiate the process by creating a proposal of a transaction. We send this transaction to the service to make it accessible by the other owners so they can give their approval and sign the transaction as well.
 
+For a full list and description of the properties see [proposeTransaction](./api-kit/reference#proposetransaction) in the API Kit reference.
+
   ```typescript
   // Create transaction
   const safeTransactionData: MetaTransactionData = {
@@ -144,7 +146,7 @@ For more detailed information, see the guide [Integrating the Protocol Kit and A
 
   ### Confirm the transaction
 
-  In this step we need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the `confirmTransaction` method.
+  In this step we need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the [confirmTransaction](./api-kit/reference#confirmtransaction) method.
 
   ```typescript
   const protocolKitOwner2 = await Safe.init({
@@ -163,6 +165,6 @@ For more detailed information, see the guide [Integrating the Protocol Kit and A
   )
   ```
 
-  The Safe transaction is now ready to be executed. This can be done using the Safe\{Wallet\} web interface, the Protocol Kit, the Safe CLI or any other tool that's available.
+  The Safe transaction is now ready to be executed. This can be done using the [Safe\{Wallet\} web](https://app.safe.global) interface, the [Protocol Kit](./protocol-kit#execute-the-transaction), the Safe CLI or any other tool that's available.
 
 </Steps>

--- a/pages/sdk/auth-kit/guides/safe-auth.mdx
+++ b/pages/sdk/auth-kit/guides/safe-auth.mdx
@@ -119,7 +119,7 @@ The `SafeAuthPack` is an authentication system that utilizes the [Web3Auth](http
 
   The `SafeAuthPack` can be used with the [Protocol Kit](../../protocol-kit.mdx) to establish a connection to a Safe using the `provider`. We don't need to pass the `signer` property in the `create()` method as it will be automatically taken from the passed `provider`.
 
-  After connecting, you can use any of the methods provided in the [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit#sdk-api).
+  After connecting, you can use any of the methods provided in the [Protocol Kit](../../protocol-kit/reference/safe).
 
   ```typescript
   // Instantiate the Protocol Kit

--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -14,7 +14,7 @@ The Safe\{Core\} SDK groups its functionality into five different kits:
 
 ## Protocol Kit
 
-The [Protocol Kit](./protocol-kit.mdx) helps interact with the Safe Smart Account contracts. It enables the creation of new Safe accounts, updating their configuration, and signing and executing transactions, among other features.
+The [Protocol Kit](./protocol-kit.mdx) helps interact with Safe Smart Accounts. It enables the creation of new Safe accounts, updating their configuration, and signing and executing transactions, among other features.
 
 - Modular and customizable smart contract accounts
 - Battle-tested security
@@ -25,6 +25,37 @@ The [Protocol Kit](./protocol-kit.mdx) helps interact with the Safe Smart Accoun
     title={'Protocol Kit'}
     description={'Learn about the Protocol Kit and the Safe Smart Account contracts integration.'}
     url={'./protocol-kit'}
+    newTab={false}
+  />
+</Grid>
+
+## API Kit
+
+The [API Kit](./api-kit.mdx) helps interact with the Safe Transaction Service API. It helps share transactions among the signers and get information from a Safe account. For example, the configuration or transaction history.
+
+<Grid container mt={3}>
+  <CustomCard
+    title={'API Kit'}
+    description={'Learn about the API Kit and the integration with the Safe Transaction Service.'}
+    url={'./api-kit'}
+    newTab={false}
+  />
+</Grid>
+
+## Relay Kit
+
+The [Relay Kit](./relay-kit.mdx) lets users pay transaction fees (gas fees) using the native blockchain token or ERC-20 tokens. Gas fees can be payed with this kit using any ERC-20 token in your Safe, even if there is no native token balance.
+
+- Use ERC-4337 with Safe.
+- Gas-less experiences using Gelato
+- Sponsored transaction
+- Pay fees in ERC-20 tokens
+
+<Grid container mt={3}>
+  <CustomCard
+    title={'Relay Kit'}
+    description={'Learn about the Relay Kit and the packs integrating ERC-4337 and Gelato.'}
+    url={'./relay-kit'}
     newTab={false}
   />
 </Grid>
@@ -46,23 +77,6 @@ The [Auth Kit](./auth-kit.mdx) creates externally owned accounts and authenticat
   />
 </Grid>
 
-## Relay Kit
-
-The [Relay Kit](./relay-kit.mdx) relays Safe transactions, allowing you to get them sponsored by a third party or paid with any supported ERC-20 token.
-
-- Gas-less experiences using Gelato
-- Sponsored transaction
-- Pay fees in ERC-20 tokens
-
-<Grid container mt={3}>
-  <CustomCard
-    title={'Relay Kit'}
-    description={'Learn about the Relay Kit and the pack integrating Gelato.'}
-    url={'./relay-kit'}
-    newTab={false}
-  />
-</Grid>
-
 ## Onramp Kit
 
 The [Onramp Kit](./onramp-kit.mdx) helps users buy cryptocurrencies with fiat money to fund a Safe account via a credit card or other payment method.
@@ -75,19 +89,6 @@ The [Onramp Kit](./onramp-kit.mdx) helps users buy cryptocurrencies with fiat mo
     title={'Onramp Kit'}
     description={'Learn about the Onramp Kit and the packs integrating Monerium and Stripe.'}
     url={'./onramp-kit'}
-    newTab={false}
-  />
-</Grid>
-
-## API Kit
-
-The [API Kit](./api-kit.mdx) helps interact with the Safe Transaction Service API. It helps share transactions among the signers and get information from a Safe account. For example, the configuration or transaction history.
-
-<Grid container mt={3}>
-  <CustomCard
-    title={'API Kit'}
-    description={'Learn about the API Kit and the integration with the Safe Transaction Service.'}
-    url={'./api-kit'}
     newTab={false}
   />
 </Grid>

--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -44,9 +44,9 @@ The [API Kit](./api-kit.mdx) helps interact with the Safe Transaction Service AP
 
 ## Relay Kit
 
-The [Relay Kit](./relay-kit.mdx) lets users pay transaction fees (gas fees) using the native blockchain token or ERC-20 tokens. Gas fees can be payed with this kit using any ERC-20 token in your Safe, even if there is no native token balance.
+The [Relay Kit](./relay-kit.mdx) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
 
-- Use ERC-4337 with Safe.
+- Use ERC-4337 with Safe
 - Gas-less experiences using Gelato
 - Sponsored transaction
 - Pay fees in ERC-20 tokens

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -95,7 +95,7 @@ const safeFactory = await SafeFactory.init({
 
 ### Deploy a Safe
 
-Calling the `deploySafe` method will deploy the desired Safe and return a Protocol Kit initialized instance ready to be used. Check the [method reference](./protocol-kt/reference/safe-factory#deploysafe) for more details on additional configuration parameters and callbacks.
+Calling the `deploySafe` method will deploy the desired Safe and return a Protocol Kit initialized instance ready to be used. Check the [method reference](./protocol-kit/reference/safe-factory#deploysafe) for more details on additional configuration parameters and callbacks.
 
 ```tsx
 import { SafeAccountConfig } from '@safe-global/protocol-kit'
@@ -165,7 +165,7 @@ The high-level overview of a multi-sig transaction is PCE: Propose. Confirm. Exe
 
 ### Create a transaction
 
-For more details on what to include in a transaction see [createTransaction](./protocol-kit/reference/safe#createtransaction) method.
+For more details on what to include in a transaction see [`createTransaction`](./protocol-kit/reference/safe#createtransaction) method.
 
 ```tsx
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
@@ -187,7 +187,7 @@ const safeTransaction = await protocolKitOwner1.createTransaction({ transactions
 
 To propose a transaction to the Safe Transaction Service we need to call the `proposeTransaction` method from the API Kit instance.
 
-For a full list and description of the properties see [proposeTransaction](./api-kit/reference#proposetransaction) in the API Kit reference.
+For a full list and description of the properties see [`proposeTransaction`](./api-kit/reference#proposetransaction) in the API Kit reference.
 
 ```tsx
 // Deterministic hash based on transaction parameters
@@ -207,7 +207,7 @@ await apiKit.proposeTransaction({
 
 ### Get pending transactions
 
-Recall that you created the `apiKit` in [Initialize the API Kit](./#initialize-the-safe-api-kit).
+Recall that you created the `apiKit` in [Initialize the API Kit](./protocol-kit/#initialize-the-safe-api-kit).
 
 ```tsx
 const pendingTransactions = (await apiKit.getPendingTransactions(safeAddress)).results

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Protocol Kit
 
-The [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) enables developers to interact with the [Safe contracts](https://github.com/safe-global/safe-contracts) using a TypeScript interface. This Kit can be used to create new Safe accounts, update the configuration of existing Safes, propose and execute transactions, among other features.
+The [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) enables developers to interact with [Safe Smart Accounts](https://github.com/safe-global/safe-smart-account) using a TypeScript interface. This Kit can be used to create new Safe accounts, update the configuration of existing Safes, propose and execute transactions, among other features.
 
 <Grid item mt={3}>
   <CustomCard
@@ -17,7 +17,7 @@ The [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packag
 
 In this quickstart guide, you will create a 2 of 3 multi-sig Safe and propose and execute a transaction to send some ETH out of this Safe.
 
-For a more detailed guide, including how to integrate with `web3.js` and more Safe transaction configuration options, see [Guide: Integrating the Protocol Kit and API Kit](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md) and [Protocol Kit Reference](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit#sdk-api).
+To find more details and configuration options for available methods, see the [Protocol Kit reference](./protocol-kit/reference).
 
 ### Prerequisites
 
@@ -82,7 +82,7 @@ const apiKit = new SafeApiKit({
 
 ### Initialize the Protocol Kit
 
-The `SafeFactory` class allows the deployment of new Safe accounts while the `Safe` class represents an instance of a specific Safe account.
+The `SafeFactory` class allows the deployment of new Safe accounts while the `Safe` class represents an instance of a specific Safe Smart Account.
 
 ```tsx
 import { SafeFactory } from '@safe-global/protocol-kit'
@@ -95,7 +95,7 @@ const safeFactory = await SafeFactory.init({
 
 ### Deploy a Safe
 
-Calling the `deploySafe` method will deploy the desired Safe and return a Protocol Kit initialized instance ready to be used. Check the [API Reference](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit#deploysafe) for more details on additional configuration parameters and callbacks.
+Calling the `deploySafe` method will deploy the desired Safe and return a Protocol Kit initialized instance ready to be used. Check the [method reference](./protocol-kt/reference/safe-factory#deploysafe) for more details on additional configuration parameters and callbacks.
 
 ```tsx
 import { SafeAccountConfig } from '@safe-global/protocol-kit'
@@ -165,7 +165,7 @@ The high-level overview of a multi-sig transaction is PCE: Propose. Confirm. Exe
 
 ### Create a transaction
 
-For more details on what to include in a transaction see [Create a Transaction in the Safe Core SDK Guide](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md#4-create-a-transaction).
+For more details on what to include in a transaction see [createTransaction](./protocol-kit/reference/safe#createtransaction) method.
 
 ```tsx
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
@@ -187,7 +187,7 @@ const safeTransaction = await protocolKitOwner1.createTransaction({ transactions
 
 To propose a transaction to the Safe Transaction Service we need to call the `proposeTransaction` method from the API Kit instance.
 
-For a full list and description of the properties that `proposeTransaction` accepts, see [Propose the transaction to the service](https://github.com/safe-global/safe-core-sdk/blob/main/guides/integrating-the-safe-core-sdk.md#propose-transaction) in the Safe Core SDK guide.
+For a full list and description of the properties see [proposeTransaction](./api-kit/reference#proposetransaction) in the API Kit reference.
 
 ```tsx
 // Deterministic hash based on transaction parameters
@@ -267,4 +267,4 @@ The final balance of the Safe: 0.005 ETH
 
 ### Conclusion
 
-In this quickstart, you learned how to create and deploy a Safe and to propose and then execute a transaction for the Safe.
+In this quickstart, you learned how to create and deploy a Safe Smart Account and to propose and then execute a transaction from it.

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -82,7 +82,7 @@ const apiKit = new SafeApiKit({
 
 ### Initialize the Protocol Kit
 
-The `SafeFactory` class allows the deployment of new Safe accounts while the `Safe` class represents an instance of a specific Safe Smart Account.
+The `SafeFactory` class allows the deployment of new Safe accounts while the `Safe` class represents an instance of a specific one.
 
 ```tsx
 import { SafeFactory } from '@safe-global/protocol-kit'
@@ -267,4 +267,4 @@ The final balance of the Safe: 0.005 ETH
 
 ### Conclusion
 
-In this quickstart, you learned how to create and deploy a Safe Smart Account and to propose and then execute a transaction from it.
+In this quickstart, you learned how to create and deploy a new Safe account and to propose and then execute a transaction from it.

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -207,7 +207,7 @@ await apiKit.proposeTransaction({
 
 ### Get pending transactions
 
-Recall that you created the `apiKit` in [Initialize the API Kit](./protocol-kit/#initialize-the-safe-api-kit).
+Recall that you created the `apiKit` in [Initialize the API Kit](./protocol-kit/#initialize-the-api-kit).
 
 ```tsx
 const pendingTransactions = (await apiKit.getPendingTransactions(safeAddress)).results

--- a/pages/sdk/protocol-kit/reference.md
+++ b/pages/sdk/protocol-kit/reference.md
@@ -1,6 +1,6 @@
 # Reference
 
-The [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) facilitates the interaction with the [Safe contracts](https://github.com/safe-global/safe-contracts).
+The [Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) facilitates the interaction with [Safe Smart Accounts](https://github.com/safe-global/safe-smart-account).
 
 ## Install dependencies
 

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
-The Relay Kit lets users pay transaction fees (gas fees) using the native blockchain token or ERC-20 tokens. Gas fees can be payed with this kit using any ERC-20 token in your Safe, even if there is no native token balance.
+The Relay Kit lets users pay transaction fees (gas fees) using the native blockchain token or ERC-20 tokens. Gas fees can be payed with this kit using any ERC-20 token in your Safe, even if there is no native token balance. This kit enables the use of ERC-4337 with Safe.
 
 <Grid item mt={3}>
   <CustomCard

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
-The Relay Kit lets users pay transaction fees (gas fees) using the native blockchain token or ERC-20 tokens. Gas fees can be payed with this kit using any ERC-20 token in your Safe, even if there is no native token balance. This kit enables the use of ERC-4337 with Safe.
+The [Relay Kit](./relay-kit.mdx) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
 
 <Grid item mt={3}>
   <CustomCard

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
-The [Relay Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/relay-kit) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
+The [Relay Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/relay-kit) enables ERC-4337 with Safe, and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or to get their transactions sponsored.
 
 <Grid item mt={3}>
   <CustomCard

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
-The [Relay Kit](./relay-kit.mdx) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
+The [Relay Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/relay-kit) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
 
 <Grid item mt={3}>
   <CustomCard


### PR DESCRIPTION
## Summary
 - Order the package from most used to least.
 - Removes broken links pointing to Protocol Kit reference in the repository instead the docs themselves.
 - Remove reference to guide in the repository to avoid moving users from docs to repo.
 - Add few more links for cross docs references.