### PR TITLE
Restore react-ga4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "node-fetch": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "release-it": "^17.3.0",
     "remark-gfm": "^4.0.0",
     "shelljs": "^0.8.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,13 +7,17 @@ import {
   experimental_extendTheme as extendMuiTheme
 } from '@mui/material/styles'
 import type { AppProps } from 'next/app'
-import { type ReactElement } from 'react'
+import { useEffect, type ReactElement } from 'react'
 import Head from 'next/head'
+import ReactGA from 'react-ga4'
 import { GoogleTagManager } from '@next/third-parties/google'
 
 import MetaTags from '../components/MetaTags'
 import { CookieBanner } from '../components/CookieBanner'
-import { CookieBannerContextProvider } from '../components/CookieBanner/CookieBannerContext'
+import {
+  CookieBannerContextProvider,
+  useCookieBannerContext
+} from '../components/CookieBanner/CookieBannerContext'
 import { createEmotionCache } from '../styles/emotion'
 import '../styles/styles.css'
 import '@code-hike/mdx/dist/index.css'
@@ -24,6 +28,38 @@ const clientSideEmotionCache = createEmotionCache()
 
 // Extended theme for CssVarsProvider
 const cssVarsTheme = extendMuiTheme(theme as CssVarsThemeOptions)
+
+let isAnalyticsInitialized = false
+
+const GoogleAnalytics: React.FC = () => {
+  const { isAnalyticsEnabled } = useCookieBannerContext()
+
+  // Enable/disable tracking
+  useEffect(() => {
+    if (
+      process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true' &&
+      isAnalyticsEnabled
+    ) {
+      ReactGA.initialize(
+        String(process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID),
+        {
+          gaOptions: {
+            cookieFlags: 'SameSite=Strict;Secure',
+            cookieDomain: process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_DOMAIN
+          }
+        }
+      )
+      isAnalyticsInitialized = true
+      return
+    }
+
+    if (!isAnalyticsEnabled && isAnalyticsInitialized) {
+      // Injected script will otherwise remain in memory until new session
+      location.reload()
+    }
+  }, [isAnalyticsEnabled])
+  return null
+}
 
 const App = ({
   Component,
@@ -44,6 +80,7 @@ const App = ({
       <CssVarsProvider theme={cssVarsTheme}>
         <CookieBannerContextProvider>
           <CssBaseline />
+          <GoogleAnalytics />
           <Component {...pageProps} />
           <CookieBanner />
         </CookieBannerContextProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-ga4:
+    specifier: ^2.1.0
+    version: 2.1.0
   release-it:
     specifier: ^17.3.0
     version: 17.3.0(typescript@5.4.2)
@@ -9083,6 +9086,10 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-ga4@2.1.0:
+    resolution: {integrity: sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==}
     dev: false
 
   /react-is@16.13.1:


### PR DESCRIPTION
Restore react-ga4 after wrongfully removed it in https://github.com/safe-global/safe-docs/pull/490. No events are received at all anymore in GA.