### PR TITLE
Fix warnings in API reference

### DIFF
--- a/components/ApiReference/ApiReference.tsx
+++ b/components/ApiReference/ApiReference.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { renderToString } from 'react-dom/server'
+import { useData } from 'nextra/ssg'
 import Grid from '@mui/material/Grid'
 import Dialog from '@mui/material/Dialog'
 import AppBar from '@mui/material/AppBar'
@@ -12,23 +12,18 @@ import Menu from '@mui/icons-material/Menu'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ExpandLess from '@mui/icons-material/ExpandLess'
 
-import TOC from './TOC'
-import {
-  getHeadingsFromHtml,
-  MDXComponents,
-  useCurrentTocIndex
-} from '../../lib/mdx'
+import TOC, { type Heading } from './TOC'
+import { MDXComponents, useCurrentTocIndex } from '../../lib/mdx'
 import Mdx from './generated-reference.mdx'
 import { NetworkProvider } from './Network'
 import css from './styles.module.css'
 
 const renderedMdx = <Mdx components={MDXComponents} />
-const contentString = renderToString(renderedMdx)
-const headings = getHeadingsFromHtml(contentString)
 
 const ApiReference: React.FC = () => {
+  const { headings } = useData()
   const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false)
-  const currentIndex = useCurrentTocIndex(headings, 100)
+  const currentIndex = useCurrentTocIndex(headings as Heading[], 100)
 
   return (
     <>

--- a/pages/core-api/transaction-service-reference.mdx
+++ b/pages/core-api/transaction-service-reference.mdx
@@ -1,3 +1,4 @@
+{/* <!-- vale off --> */}
 import ApiReference from '../../components/ApiReference'
 import { renderToString } from 'react-dom/server'
 import { MDXComponents, getHeadingsFromHtml } from '../../lib/mdx'
@@ -16,3 +17,4 @@ export const getStaticProps = async () => {
 }
 
 <ApiReference />
+{/* <!-- vale on --> */}

--- a/pages/core-api/transaction-service-reference.mdx
+++ b/pages/core-api/transaction-service-reference.mdx
@@ -1,3 +1,18 @@
 import ApiReference from '../../components/ApiReference'
+import { renderToString } from 'react-dom/server'
+import { MDXComponents, getHeadingsFromHtml } from '../../lib/mdx'
+import Mdx from '../../components/ApiReference/generated-reference.mdx'
+
+export const getStaticProps = async () => {
+  const renderedMdx = <Mdx components={MDXComponents} />
+  const contentString = renderToString(renderedMdx)
+  const headings = getHeadingsFromHtml(contentString)
+
+  return {
+    props: {
+      ssg: { headings }
+    }
+  }
+}
 
 <ApiReference />


### PR DESCRIPTION
The console displayed a few thousand warnings on the API reference page about the use of useLayoutEffect inside components that are rendered and then stringified client-side. This made devtools crash and slowed down development.