### PR TITLE
docs: Update Passkey type

### DIFF
--- a/pages/home/passkeys-guides/safe-sdk.mdx
+++ b/pages/home/passkeys-guides/safe-sdk.mdx
@@ -76,22 +76,16 @@ yarn add @safe-global/protocol-kit
 
   {/* <!-- vale on --> */}
 
-  After generating the `passkeyCredential` object, we need to create a new object with the `PasskeyArgType` type that will contain the `rawId` and the `publicKey` information.
+  After generating the `passkeyCredential` object, we need to create a new object with the `PasskeyArgType` type that will contain the `rawId` and the `coordinates` information.
 
   {/* <!-- vale off --> */}
 
   ```typescript
-  const passkeyObject = passkeyCredential as PublicKeyCredential
-  const attestationResponse =
-    passkeyObject.response as AuthenticatorAttestationResponse
-
-  const rawId = passkeyObject.rawId
-  const publicKey = attestationResponse.getPublicKey()
-
-  const passkey: PasskeyArgType = {
-    rawId,
-    publicKey
+  if (!passkeyCredential) {
+    throw Error("Passkey creation failed: No credential was returned.");
   }
+
+  const passkey = await extractPasskeyData(passkeyCredential);
   ```
 
   {/* <!-- vale on --> */}

--- a/pages/sdk/protocol-kit/reference/safe-factory.md
+++ b/pages/sdk/protocol-kit/reference/safe-factory.md
@@ -24,7 +24,7 @@ import { SafeFactory, PasskeyArgType } from '@safe-global/protocol-kit'
 
 const passkey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 
 const safeFactory = await SafeFactory.init({

--- a/pages/sdk/protocol-kit/reference/safe.md
+++ b/pages/sdk/protocol-kit/reference/safe.md
@@ -46,7 +46,7 @@ import Safe from '@safe-global/protocol-kit'
 
 const passkey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 
 const protocolKit = await Safe.init({
@@ -542,7 +542,7 @@ Instead of using an address, this method also supports the use of a passkey to s
 ```typescript
 const passkey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 const params: AddPasskeyOwnerTxParams = {
   passkey,
@@ -579,7 +579,7 @@ Instead of using an address, this method also supports the use of a passkey to r
 ```typescript
 const passkey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 const params: AddPasskeyOwnerTxParams = {
   passkey,
@@ -616,7 +616,7 @@ Instead of using an address, this method also supports any combination of passke
 ```typescript
 const newOwnerPasskey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 const params: SwapOwnerTxParams = {
   oldOwnerAddress,
@@ -668,7 +668,7 @@ A passkey can also be used to check if the signer account is an owner of the cur
 ```typescript
 const passkey: PasskeyArgType = {
   rawId,
-  publicKey,
+  coordinates,
 }
 
 const isOwner = await protocolKit.isOwner(passkey)


### PR DESCRIPTION
Updated the `PasskeyArgType` type from:

```typescript
export type PasskeyArgType = {
  rawId: ArrayBuffer // required to sign data
  publicKey: ArrayBuffer // required to generate X & Y Coordinates
}
```

to:

```typescript
export type PasskeyArgType = {
  rawId: string // required to sign data
  coordinates: PasskeyCoordinates // required to sign data
  customVerifierAddress?: string // optional
}
```

Creating and storing a passkey should be easier:

```typescript
import { PasskeyArgType, extractPasskeyData } from "@safe-global/protocol-kit";

  // Generate a passkey credential using WebAuthn API
  const passkeyCredential = await navigator.credentials.create({
    publicKey: {
      pubKeyCredParams: [
        {
          // ECDSA w/ SHA-256: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
          alg: -7,
          type: "public-key",
        },
      ],
      challenge: crypto.getRandomValues(new Uint8Array(32)),
      rp: {
        name: "Safe SmartAccount",
      },
      user: {
        displayName: label,
        id: crypto.getRandomValues(new Uint8Array(32)),
        name: label,
      },
      timeout: 60_000,
      attestation: "none",
    },
  });

  if (!passkeyCredential) {
    throw Error("Passkey creation failed: No credential was returned.");
  }

  const passkey = await extractPasskeyData(passkeyCredential);

  console.log("new passkey created: ", passkey);
```