### PR TITLE
docs: add missing comma to paymasterOptions object

### DIFF
--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -111,7 +111,7 @@ yarn add @safe-global/relay-kit
       const safe4337Pack = await Safe4337Pack.init({
         // ...
         paymasterOptions: {
-          paymasterAddress: '0x...'
+          paymasterAddress: '0x...',
           paymasterTokenAddress: '0x...',
           amountToApprove // Optional
         }


### PR DESCRIPTION
In the Safe SDK guide there is a missing comma in the `paymasterOptions` object. This PR adds the missing comma. [Section](https://docs.safe.global/home/4337-guides/safe-sdk#initialize-the-safe4337pack) -> With an ERC-20 Paymaster tab

**Current**
```ts
const safe4337Pack = await Safe4337Pack.init({
  // ...
  paymasterOptions: {
    paymasterAddress: '0x...'
    paymasterTokenAddress: '0x...',
    amountToApprove // Optional
  }
})
```

**Updated**
```ts
const safe4337Pack = await Safe4337Pack.init({
  // ...
  paymasterOptions: {
    paymasterAddress: '0x...',
    paymasterTokenAddress: '0x...',
    amountToApprove // Optional
  }
})
```
