### PR TITLE
Update 7579-tutorial.mdx

### DIFF
--- a/pages/advanced/erc-7579/tutorials/7579-tutorial.mdx
+++ b/pages/advanced/erc-7579/tutorials/7579-tutorial.mdx
@@ -52,7 +52,7 @@ For this project, we'll use Pimlico's [Permissionless.js](https://docs.pimlico.i
 Run the following command to add all these dependencies to the project:
 
 ```shell
-pnpm add permissionless viem @rhinestone/module-sdk@0.1.5
+pnpm add permissionless viem @rhinestone/module-sdk@0.1.4
 ```
 
 Now, create a file named `.env.local` at the root of your project, and add your Pimlico API key to it:

--- a/pages/advanced/erc-7579/tutorials/7579-tutorial.mdx
+++ b/pages/advanced/erc-7579/tutorials/7579-tutorial.mdx
@@ -52,7 +52,7 @@ For this project, we'll use Pimlico's [Permissionless.js](https://docs.pimlico.i
 Run the following command to add all these dependencies to the project:
 
 ```shell
-pnpm add permissionless viem @rhinestone/module-sdk
+pnpm add permissionless viem @rhinestone/module-sdk@0.1.5
 ```
 
 Now, create a file named `.env.local` at the root of your project, and add your Pimlico API key to it:


### PR DESCRIPTION
Fixed version for @rhinestone/module-sdk@0.1.4 so that the ERC-7579 tutorial works. The new rhinestone version doesnt work with the example code.