### PR TITLE
fix: Update erc7579LaunchpadAddress

### DIFF
--- a/examples/erc-7579/lib/permissionless.ts
+++ b/examples/erc-7579/lib/permissionless.ts
@@ -27,7 +27,7 @@ export type SafeSmartAccountClient = SmartAccountClient<
 
 const pimlicoUrl = `https://api.pimlico.io/v2/sepolia/rpc?apikey=${process.env.NEXT_PUBLIC_PIMLICO_API_KEY}`
 const safe4337ModuleAddress = '0x3Fdb5BC686e861480ef99A6E3FaAe03c0b9F32e2'
-const erc7569LaunchpadAddress = '0xEBe001b3D534B9B6E2500FB78E67a1A137f561CE'
+const erc7579LaunchpadAddress = '0xEBe001b3D534B9B6E2500FB78E67a1A137f561CE'
 
 const privateKey =
   (process.env.NEXT_PUBLIC_PRIVATE_KEY as Hex) ??
@@ -60,7 +60,7 @@ export const getSmartAccountClient = async () => {
     safeVersion: '1.4.1',
     saltNonce: 120n,
     safe4337ModuleAddress,
-    erc7569LaunchpadAddress
+    erc7579LaunchpadAddress
   })
 
   const smartAccountClient = createSmartAccountClient({


### PR DESCRIPTION
## Context
This PR:
- Replaces `erc7569LaunchpadAddress` with `erc7579LaunchpadAddress` in the ERC-7579 tutorial because there was a typo in the ERC number.