### PR TITLE
docs: Update Onramp Kit removal

### DIFF
--- a/pages/sdk/onramp/stripe.mdx
+++ b/pages/sdk/onramp/stripe.mdx
@@ -56,7 +56,7 @@ It will return a unique `client_secret` that you can use to initialize the Strip
 
 To ensure you don't leak your private key, you should make the request from your backend.
 The backend can then send the `client_secret` to your front end.
-You can use the [example Stripe server](https://github.com/safe-global/safe-core-sdk/tree/main/packages/onramp-kit/example/server) as a starting point for your backend.
+You can use the [Stripe server example](https://github.com/5afe/stripe-server-example) as a starting point for your backend.
 
 Here is how you generate a crypto onramp session using your private key:
 

--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -58,22 +58,6 @@ The [Relay Kit](./relay-kit.mdx) enables ERC-4337 with Safe and allows users to 
   />
 </Grid>
 
-## Onramp Kit
-
-The [Onramp Kit](./onramp-kit.mdx) helps users buy cryptocurrencies with fiat money to fund a Safe account via a credit card or other payment method.
-
-- Seamless fiat on-ramping
-- Pay using a credit card
-
-<Grid container mt={3}>
-  <CustomCard
-    title={'Onramp Kit'}
-    description={'Learn about the Onramp Kit and the packs integrating Monerium and Stripe.'}
-    url={'./onramp-kit'}
-    newTab={false}
-  />
-</Grid>
-
 ## Resources
 - [Safe\{Core\} Account Abstraction SDK on GitHub](https://github.com/safe-global/safe-core-sdk)
 - [Safe\{Core\} Account Abstraction SDK demo application](https://github.com/5afe/account-abstraction-demo-ui)


### PR DESCRIPTION
## Context

`stripe-server-example` GitHub repository copied from the Safe{Core} SDK repository (as it will be removed at some point) to a new location [here](https://github.com/5afe/stripe-server-example).

This PR:
- Updates the link pointing to the new Stripe server example repository.
- Removes Onramp Kit section from SDK overview.
