### PR TITLE
fix: Update broken links

### DIFF
--- a/pages/advanced/cli-reference/common-commands.mdx
+++ b/pages/advanced/cli-reference/common-commands.mdx
@@ -257,7 +257,7 @@ change_master_copy <address>
 
 Updates a `v1.1.1`, `v1.3.0`, or `v1.4.1` non-L2 Safe to an L2 Safe supported by Safe \{Wallet\}.
 The migration contract address needs to be provided.
-It can be found [here](https://github.com/safe-global/safe-contracts/blob/main/contracts/libraries/SafeToL2Migration.sol).
+It can be found [here](https://github.com/safe-global/safe-smart-account/blob/main/contracts/libraries/SafeToL2Migration.sol).
 The nonce for the Safe must be 0, and supported versions are `v1.1.1`, `v1.3.0`, and `v1.4.1`.
 
 ```bash

--- a/pages/advanced/smart-account-audits.md
+++ b/pages/advanced/smart-account-audits.md
@@ -2,12 +2,12 @@
 
 We take great care of ensuring the security of our smart contracts. Please find the audit reports of the Safe smart contracts and the Allowance Safe Module (spending limit) below:
 
-* [Safe v1.4.0](https://github.com/safe-global/safe-contracts/blob/v1.4.0/docs/audit_1_4_0.md)
-* [Safe v1.3.0](https://github.com/safe-global/safe-contracts/blob/v1.3.0/docs/audit_1_3_0.md)
-* [Safe v1.2.0](https://github.com/safe-global/safe-contracts/blob/v1.2.0/docs/audit_1_2_0.md)
-* [Safe v1.1.0 & v1.1.1](https://github.com/safe-global/safe-contracts/blob/v1.1.1/docs/audit_1_1_1.md)
-* [Safe v1.0.0](https://github.com/safe-global/safe-contracts/blob/v1.1.1/docs/Gnosis_Safe_Formal_Verification_Report_1_0_0.pdf)
-* [Safe v0.0.1](https://github.com/safe-global/safe-contracts/blob/v1.1.1/docs/alexey_audit.md)
+* [Safe v1.4.0](https://github.com/safe-global/safe-smart-account/blob/v1.4.0/docs/audit_1_4_0.md)
+* [Safe v1.3.0](https://github.com/safe-global/safe-smart-account/blob/v1.3.0/docs/audit_1_3_0.md)
+* [Safe v1.2.0](https://github.com/safe-global/safe-smart-account/blob/v1.2.0/docs/audit_1_2_0.md)
+* [Safe v1.1.0 & v1.1.1](https://github.com/safe-global/safe-smart-account/blob/v1.1.1/docs/audit_1_1_1.md)
+* [Safe v1.0.0](https://github.com/safe-global/safe-smart-account/blob/v1.1.1/docs/Gnosis_Safe_Formal_Verification_Report_1_0_0.pdf)
+* [Safe v0.0.1](https://github.com/safe-global/safe-smart-account/blob/v1.1.1/docs/alexey_audit.md)
 * [Allowance Module v0.1.0](https://github.com/safe-global/safe-modules/blob/47e2b486b0b31d97bab7648a3f76de9038c6e67b/allowances/AllowanceModuleAuditOct2020.md)
 
 Did you find a bug? Please [get in touch](mailto:bounty@safe.global) with us via our [bug bounty program](./smart-account-bug-bounty.md).

--- a/pages/advanced/smart-account-bug-bounty.md
+++ b/pages/advanced/smart-account-bug-bounty.md
@@ -19,10 +19,10 @@ Many of the [Ethereum Foundation's bug bounty program rules](https://bounty.ethe
 
 The scope of the bug bounty program includes the core contracts related to the following releases of the Safe contracts:
 
-* v1.4.1 ([Release details](https://github.com/safe-global/safe-contracts/releases/tag/v1.4.1), [README](https://github.com/safe-global/safe-contracts/blob/v1.4.1/README.md))
-* _v1.3.0_ ([Release details](https://github.com/safe-global/safe-contracts/releases/tag/v1.3.0), [README](https://github.com/safe-global/safe-contracts/blob/v1.3.0/README.md))
-* _v1.2.0_ ([Release details](https://github.com/safe-global/safe-contracts/releases/tag/v1.2.0), [README](https://github.com/safe-global/safe-contracts/blob/v1.2.0/README.md))
-* _v1.1.1_ ([Release details](https://github.com/safe-global/safe-contracts/releases/tag/v1.1.1), [README](https://github.com/safe-global/safe-contracts/blob/v1.1.1/README.md))
+* v1.4.1 ([Release details](https://github.com/safe-global/safe-smart-account/releases/tag/v1.4.1), [README](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/README.md))
+* _v1.3.0_ ([Release details](https://github.com/safe-global/safe-smart-account/releases/tag/v1.3.0), [README](https://github.com/safe-global/safe-smart-account/blob/v1.3.0/README.md))
+* _v1.2.0_ ([Release details](https://github.com/safe-global/safe-smart-account/releases/tag/v1.2.0), [README](https://github.com/safe-global/safe-smart-account/blob/v1.2.0/README.md))
+* _v1.1.1_ ([Release details](https://github.com/safe-global/safe-smart-account/releases/tag/v1.1.1), [README](https://github.com/safe-global/safe-smart-account/blob/v1.1.1/README.md))
 
 The scope of the bug bounty also includes officially supported Safe Modules:
 * _v0.1.0_ [Allowance Module](https://github.com/safe-global/safe-modules/tree/47e2b486b0b31d97bab7648a3f76de9038c6e67b/allowances)
@@ -77,7 +77,7 @@ You can find addresses for deployed instances of these contracts [here](./smart-
 
 ## Intended behavior
 
-Please refer to the [README file](https://github.com/safe-global/safe-contracts/blob/v1.4.1/README.md) and the [release details](https://github.com/safe-global/safe-contracts/releases) of the respective contract version on GitHub as well as our [developer docs](https://docs.safe.global) for an extensive overview of the intended behavior of the smart contracts.
+Please refer to the [README file](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/README.md) and the [release details](https://github.com/safe-global/safe-smart-account/releases) of the respective contract version on GitHub as well as our [developer docs](https://docs.safe.global) for an extensive overview of the intended behavior of the smart contracts.
 
 For the modules, please refer to their corresponding READMEs:
 * [Allowance Module](https://github.com/safe-global/safe-modules/tree/allowance/v0.1.1/modules/allowances/README.md).

--- a/pages/advanced/smart-account-bug-bounty/past-paid-bounties.md
+++ b/pages/advanced/smart-account-bug-bounty/past-paid-bounties.md
@@ -4,21 +4,21 @@ _This list includes valid submissions from past and current contract versions fo
 
 ## Potential suicide of MultiSend library
 
-We use a [MultiSend](https://github.com/safe-global/safe-contracts/blob/v1.2.0/contracts/libraries/MultiSend.sol) library to batch multiple transactions together. A transaction could be created that would self-destruct the contract. While this would not have put any funds at risk, user experience would have been seriously impacted.
+We use a [MultiSend](https://github.com/safe-global/safe-smart-account/blob/v1.2.0/contracts/libraries/MultiSend.sol) library to batch multiple transactions together. A transaction could be created that would self-destruct the contract. While this would not have put any funds at risk, user experience would have been seriously impacted.
 
-We've updated the library as well as our interfaces. Details about the fix can be found on [GitHub](https://github.com/safe-global/safe-contracts/pull/156).
+We've updated the library as well as our interfaces. Details about the fix can be found on [GitHub](https://github.com/safe-global/safe-smart-account/pull/156).
 
 This bug was submitted by [Micah Zoltu](https://x.com/micahzoltu). It was regarded as a "Low Threat," and a bounty of 1,000 USD has been paid out.
 
 ## Transaction failure when receiving funds via `transfer` or `send`
 
-Since the beginning of the bug bounty period, the contract update has been live on the Ethereum Mainnet. We performed extensive internal testing and discovered an edge case where a Safe couldn't receive funds from another contract via `send` or `transfer`. This was due to additional gas costs caused by the [emission of additional events](https://github.com/safe-global/safe-contracts/pull/135) and [gas price changes](https://eips.ethereum.org/EIPS/eip-1884) in the latest hard fork. This issue has been fixed, and more details can be found on [GitHub](https://github.com/safe-global/safe-contracts/issues/149).
+Since the beginning of the bug bounty period, the contract update has been live on the Ethereum Mainnet. We performed extensive internal testing and discovered an edge case where a Safe couldn't receive funds from another contract via `send` or `transfer`. This was due to additional gas costs caused by the [emission of additional events](https://github.com/safe-global/safe-smart-account/pull/135) and [gas price changes](https://eips.ethereum.org/EIPS/eip-1884) in the latest hard fork. This issue has been fixed, and more details can be found on [GitHub](https://github.com/safe-global/safe-smart-account/issues/149).
 
 ## Duplicate owners during setup could render Safe unusable
 
 A bug in the `setupOwners` function on `OwnerManager.sol` allows duplicate owners to be set when the duplicated address is next to itself in the `_owners` array. This could cause unexpected behavior. While stealing funds from existing Safes is impossible, it's unexpected, and user funds might be locked. During Safe creation, the threshold of a Safe could be set to something unreachable, making it impossible to execute a transaction afterward.
 
-The Safe interfaces prevent this by checking for duplicates, but if users directly interact with the contracts, this can still happen. The issue is tracked on [GitHub](https://github.com/safe-global/safe-contracts/issues/244).
+The Safe interfaces prevent this by checking for duplicates, but if users directly interact with the contracts, this can still happen. The issue is tracked on [GitHub](https://github.com/safe-global/safe-smart-account/issues/244).
 
 This bug was submitted by [David Nicholas](https://x.com/davidnich11). It was regarded as a "Medium Threat," and a bounty of 2,500 USD has been paid out.
 
@@ -30,13 +30,13 @@ To our knowledge, there is no actual use case where it would make sense to set a
 
 To fix this, the next contract update will prevent the Safe as its owner via `require(owner != address(this), "Safe can't be an owner")`. This check can be performed when adding owners and/or when checking signatures.
 
-Details about this issue can be found on [GitHub](https://github.com/safe-global/safe-contracts/issues/229).
+Details about this issue can be found on [GitHub](https://github.com/safe-global/safe-smart-account/issues/229).
 
 The bug was submitted by [Kevin Foesenek](https://github.com/keviinfoes). It was regarded as a "Medium Threat," and a bounty of 5,000 USD has been paid out.
 
 ## The function `getModulesPaginated` doesn't return all modules
 
-The method [getModuledPaginated](https://github.com/safe-global/safe-contracts/blob/v1.3.0/contracts/base/ModuleManager.sol#L114) is used to return enabled modules page by page. For this, a `start` and a `pageSize` need to be specified, and the method will return an array of Safe Module addresses and `next`. This next can be used as the `start` to load the next page. When another page exists, then `next` is a module address. This module address, however, won't be present in any of the returned arrays. While this doesn't put any user assets at risk directly, it could lead to a wrong perception of the enabled modules of a Safe and, thereby, its state.
+The method [getModuledPaginated](https://github.com/safe-global/safe-smart-account/blob/v1.3.0/contracts/base/ModuleManager.sol#L114) is used to return enabled modules page by page. For this, a `start` and a `pageSize` need to be specified, and the method will return an array of Safe Module addresses and `next`. This next can be used as the `start` to load the next page. When another page exists, then `next` is a module address. This module address, however, won't be present in any of the returned arrays. While this doesn't put any user assets at risk directly, it could lead to a wrong perception of the enabled modules of a Safe and, thereby, its state.
 
 The workaround is to append the `next` to the returned array of module addresses if it's not the zero or sentinel address. Alternatively, the last element of the returned array can be used as the `start` for the next page.
 
@@ -44,7 +44,7 @@ This bug was submitted by [Renan Souza](https://github.com/RenanSouza2). It was 
 
 ## Signature verification does not enforce a maximum size on the signature bytes
 
-The function [`checkNSignatures`](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol#L274) does not enforce a size limit on the signature bytes. This means that they can be padded with arbitrary data. This can be used by manipulating the `signatures` by padding them with additional data while remaining valid and, since the `signatures` bytes get copied from `calldata` into memory, increase the total gas consumption of the `checkNSignatures` function. This is an issue when the Safe is combined with the [ERC-4337 module](https://github.com/safe-global/safe-modules/tree/4337/v0.3.0/modules/4337), where the account pays the gas costs for the ERC-4337 user operation. A malicious relayer can grief the account by padding the `signatures` bytes to include extra 0s, causing the account to pay more fees than it would have with optimally encoded `signatures` bytes.
+The function [`checkNSignatures`](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/Safe.sol#L274) does not enforce a size limit on the signature bytes. This means that they can be padded with arbitrary data. This can be used by manipulating the `signatures` by padding them with additional data while remaining valid and, since the `signatures` bytes get copied from `calldata` into memory, increase the total gas consumption of the `checkNSignatures` function. This is an issue when the Safe is combined with the [ERC-4337 module](https://github.com/safe-global/safe-modules/tree/4337/v0.3.0/modules/4337), where the account pays the gas costs for the ERC-4337 user operation. A malicious relayer can grief the account by padding the `signatures` bytes to include extra 0s, causing the account to pay more fees than it would have with optimally encoded `signatures` bytes.
 
 The workaround is to set a strict `verificationGasLimit` for ERC-4337 user operations. This would set a strict upper bound on how much gas can be paid during signature verification and limit the potential additional fees.
 

--- a/pages/advanced/smart-account-guards.mdx
+++ b/pages/advanced/smart-account-guards.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 
 <Callout type='info' emoji='ℹ️'>
   Safe Guards are introduced with [Safe contracts version
-  1.3.0](https://GitHub.com/safe-global/safe-contracts/blob/v1.3.0/CHANGELOG.md).
+  1.3.0](https://GitHub.com/safe-global/safe-smart-account/blob/v1.3.0/CHANGELOG.md).
 </Callout>
 
 Safe Guards are used when there are restrictions on top of the `n`-out-of-`m` scheme.

--- a/pages/advanced/smart-account-overview.mdx
+++ b/pages/advanced/smart-account-overview.mdx
@@ -50,4 +50,4 @@ Here are some core components of a Safe Smart Account that you will learn about:
 
 ### Signatures
 
-Safe contracts support alternative signature schemes such as [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) and relaying by making the confirmation/verification logic independent of `msg.sender`. Read more about the [signature schemes](https://github.com/safe-global/safe-contracts/blob/main/docs/signatures.md) supported by Safe.
+Safe contracts support alternative signature schemes such as [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) and relaying by making the confirmation/verification logic independent of `msg.sender`. Read more about the [signature schemes](https://github.com/safe-global/safe-smart-account/blob/main/docs/signatures.md) supported by Safe.

--- a/pages/advanced/smart-account-signatures.md
+++ b/pages/advanced/smart-account-signatures.md
@@ -64,7 +64,7 @@ The method `signMessage` can be used to mark a message as signed on-chain.
 
 `{32-bytes hash validator}{32-bytes ignored}{1-byte signature type}`
 
-**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre-validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it's possible to set a hash as validated by a certain address (hash validator). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it's **not** required to use `approveHash` to add an entry to the mapping. (This can be seen in the [Team Edition tests](https://github.com/gnosis/safe-contracts/blob/v1.0.0/test/gnosisSafeTeamEdition.js))
+**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre-validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it's possible to set a hash as validated by a certain address (hash validator). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it's **not** required to use `approveHash` to add an entry to the mapping. (This can be seen in the [Team Edition tests](https://github.com/gnosis/safe-smart-account/blob/v1.0.0/test/gnosisSafeTeamEdition.js))
 
 **Signature type** - 1
 

--- a/pages/advanced/smart-account-signatures.md
+++ b/pages/advanced/smart-account-signatures.md
@@ -64,7 +64,7 @@ The method `signMessage` can be used to mark a message as signed on-chain.
 
 `{32-bytes hash validator}{32-bytes ignored}{1-byte signature type}`
 
-**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre-validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it's possible to set a hash as validated by a certain address (hash validator). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it's **not** required to use `approveHash` to add an entry to the mapping. (This can be seen in the [Team Edition tests](https://github.com/gnosis/safe-smart-account/blob/v1.0.0/test/gnosisSafeTeamEdition.js))
+**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre-validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it's possible to set a hash as validated by a certain address (hash validator). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it's **not** required to use `approveHash` to add an entry to the mapping. (This can be seen in the [Team Edition tests](https://github.com/safe-global/safe-smart-account/blob/v1.0.0/test/gnosisSafeTeamEdition.js))
 
 **Signature type** - 1
 

--- a/pages/core-api/api-safe-transaction-service.mdx
+++ b/pages/core-api/api-safe-transaction-service.mdx
@@ -163,8 +163,8 @@ For every new contract, the service tries to download the source, and the ABI re
 Supported and configured networks on `safe-eth-py`:   
 
 - [**Sourcify** supported networks](https://docs.sourcify.dev/docs/chains/)
-- [**Etherscan** configured networks](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/clients/etherscan_client.py#L24)
-- [**Blockscout** configured networks](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/clients/blockscout_client.py#L21)
+- [**Etherscan** configured networks](https://github.com/safe-global/safe-eth-py/blob/main/safe_eth/eth/clients/etherscan_client.py#L24)
+- [**Blockscout** configured networks](https://github.com/safe-global/safe-eth-py/blob/main/safe_eth/eth/clients/blockscout_client.py#L21)
 
 
 Follow our [guides](../core-api/transaction-service-guides/data-decoder.mdx) to learn how to decode contract interaction data using the Safe Transaction Service for a transaction.

--- a/pages/core-api/safe-infrastructure-deployment.mdx
+++ b/pages/core-api/safe-infrastructure-deployment.mdx
@@ -120,7 +120,7 @@ After all the components are up and running, you need to configure the Transacti
 
 #### Transaction Service
 
-By default, Transaction Service will automatically setup `MasterCopies` and `Proxy Factories` for [a list of known networks](https://github.com/safe-global/safe-eth-py/blob/main/gnosis/safe/addresses.py). 
+By default, Transaction Service will automatically setup `MasterCopies` and `Proxy Factories` for [a list of known networks](https://github.com/safe-global/safe-eth-py/blob/main/safe_eth/safe/addresses.py). 
 
 If your network is not supported you have to add the addresses manually in `http://YOUR_TRANSACTION_SERVICE_DOMAIN/admin/` in **Proxy Factories** and also in **Safe master copies** section.
 

--- a/pages/sdk/protocol-kit/guides/signatures/messages.mdx
+++ b/pages/sdk/protocol-kit/guides/signatures/messages.mdx
@@ -243,7 +243,7 @@ Using the Protocol Kit, this guide explains how to generate and sign messages fr
   Safe messages can be stored on-chain and off-chain:
 
   - **Off-chain**: Messages are stored in the Safe Transaction Service. This is the default option and doesn't require any on-chain interaction.
-  - **On-chain**: Messages are [stored](https://github.com/safe-global/safe-contracts/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L68-L69) in the Safe contract.
+  - **On-chain**: Messages are [stored](https://github.com/safe-global/safe-smart-account/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L68-L69) in the Safe contract.
 
   Safe supports signing [EIP-191](https://eips.ethereum.org/EIPS/eip-191) messages and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data messages all together with off-chain [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) validation for signatures.
 
@@ -378,7 +378,7 @@ Using the Protocol Kit, this guide explains how to generate and sign messages fr
 
   #### Off-chain
 
-  When a message is stored off-chain, the `isValidSignature` method in the Protocol Kit must be called with the `messageHash` and the `encodedSignatures` parameters. The method will check the `isValidSignature` function defined in the `CompatibilityFallbackHandler` [contract](https://github.com/safe-global/safe-contracts/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/handler/CompatibilityFallbackHandler.sol#L51-L68) to validate the signature.
+  When a message is stored off-chain, the `isValidSignature` method in the Protocol Kit must be called with the `messageHash` and the `encodedSignatures` parameters. The method will check the `isValidSignature` function defined in the `CompatibilityFallbackHandler` [contract](https://github.com/safe-global/safe-smart-account/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/handler/CompatibilityFallbackHandler.sol#L51-L68) to validate the signature.
 
   ```typescript
   const encodedSignatures = safeMessage.encodedSignatures()

--- a/pages/sdk/protocol-kit/guides/signatures/transactions.mdx
+++ b/pages/sdk/protocol-kit/guides/signatures/transactions.mdx
@@ -231,7 +231,7 @@ This guide explains how transactions are signed by the Safe owners using the Pro
   | Hex | Hex string characters | 1 | 0x |
   | Verifier | Padded address of the contract that implements the EIP-1271 interface to verify the signature. The Safe signer address | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>000000000000000000000000215033cdE0619D60B7352348F4598316Cc39bC6E</div> |
   | Data position | Start position of the signature data (offset relative to the beginning of the signature data). 41 hex is 65 in decimal | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>0000000000000000000000000000000000000000000000000000000000000041</div> |
-  | Signature Type | [00 for Safe accounts](https://github.com/safe-global/safe-contracts/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L322-L336) | 1 | 00 |
+  | Signature Type | [00 for Safe accounts](https://github.com/safe-global/safe-smart-account/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L322-L336) | 1 | 00 |
   | Signature Length | The length of the signature. 41 hex is 65 in decimal | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>0000000000000000000000000000000000000000000000000000000000000041</div> |
   | Signature | Signature bytes that are verified by the signature verifier | 65 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>5edb6ffe67dd935d93d07c634970944ba0b096f767b92018ad635e8b28effeea5a1e512f1ad6f886690e0e30a3fae2c8c61d3f83d24d43276acdb3254b92ea5b1f</div> |
 
@@ -326,7 +326,7 @@ This guide explains how transactions are signed by the Safe owners using the Pro
   | Hex | Hex string characters | 1 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>0x</div> |
   | Verifier | Padded address of the contract that implements the EIP-1271 interface to verify the signature. The Safe signer address | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>000000000000000000000000f75D61D6C27a7CC5788E633c1FC130f0F4a62D33</div> |
   | Data position | Start position of the signature data (offset relative to the beginning of the signature data). 41 hex is 65 in decimal | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>0000000000000000000000000000000000000000000000000000000000000041</div> |
-  | Signature Type | [00 for Safe accounts](https://github.com/safe-global/safe-contracts/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L322-L336) | 1 | 00 
+  | Signature Type | [00 for Safe accounts](https://github.com/safe-global/safe-smart-account/blob/f03dfae65fd1d085224b00a10755c509a4eaacfe/contracts/Safe.sol#L322-L336) | 1 | 00 
   | Signature Length | The length of the signature. 82 hex is 130 in decimal | 32 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>0000000000000000000000000000000000000000000000000000000000000082</div> |
   | Signature | Signature bytes that are verified by the signature verifier (130 bytes are represented by 260 characters in an hex string) | 130 | <div style={{ maxWidth: "300px", textWrap: "wrap" }}>023d1746ed548e90f387a6b8ddba26e6b80a78d5bfbc36e5bfcbfd63e136f8071db6e91c037fa36bde72159138bbb74fc359b35eb515e276a7c0547d5eaa042520d3e6565e5590641db447277243cf24711dce533cfcaaf3a64415dcb9fa309fbf2de1ae4709c6450752acc0d45e01b67b55379bdf4e3dc32b2d89ad0a60c231d61f</div> |
 

--- a/pages/sdk/protocol-kit/reference/safe-factory.mdx
+++ b/pages/sdk/protocol-kit/reference/safe-factory.mdx
@@ -38,7 +38,7 @@ const safeFactory = await SafeFactory.init({
 
 - The `isL1SafeSingleton` flag
 
-  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
+  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
   By default, `Safe.sol` will only be used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force using the `Safe.sol` contract.
 

--- a/pages/sdk/protocol-kit/reference/safe.mdx
+++ b/pages/sdk/protocol-kit/reference/safe.mdx
@@ -61,7 +61,7 @@ const protocolKit = await Safe.init({
 
 - The `isL1SafeSingleton` flag
 
-  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
+  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
   By default `Safe.sol` will only be used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force using the `Safe.sol` contract.
 
@@ -162,7 +162,7 @@ protocolKit = await protocolKit.connect({ predictedSafe })
 
 - The `isL1SafeSingleton` flag
 
-  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-contracts/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
+  Two versions of the Safe contracts are available: [Safe.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/Safe.sol) that doesn't trigger events to save gas and [SafeL2.sol](https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/SafeL2.sol) that does, which is more appropriate for L2 networks.
 
   By default `Safe.sol` will only be used on Ethereum Mainnet. For the rest of the networks where the Safe contracts are already deployed, the `SafeL2.sol` contract will be used unless you add the `isL1SafeSingleton` flag to force using the `Safe.sol` contract.
 


### PR DESCRIPTION
## Context
This PR:
- Fixes broken links pointing to `safe-eth-py` repo.
- Updates links pointing to `safe-contracts` to `safe-smart-account` repo