### PR TITLE
fix: Update Glossary links

### DIFF
--- a/pages/advanced/erc-4337/4337-safe.mdx
+++ b/pages/advanced/erc-4337/4337-safe.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 
 Safe has adopted a modular and flexible approach to integrating the ERC-4337, allowing users to turn their Safe account into an ERC-4337 smart account.
 
-Safe ERC-4337 compatibility is provided via [Safe Modules](../../glossary.md#safe-module) and the Fallback Handler. This means the functionality is not implemented directly in the Safe Smart Account, but in the [Safe4337Module](https://github.com/safe-global/safe-modules/blob/main/modules/4337/contracts/Safe4337Module.sol) contract, which can be enabled in any Safe account at the Safe deployment time or afterward.
+Safe ERC-4337 compatibility is provided via [Safe Modules](../../home/glossary.md#safe-module) and the Fallback Handler. This means the functionality is not implemented directly in the Safe Smart Account, but in the [Safe4337Module](https://github.com/safe-global/safe-modules/blob/main/modules/4337/contracts/Safe4337Module.sol) contract, which can be enabled in any Safe account at the Safe deployment time or afterward.
 
 ## Safe4337Module
 

--- a/pages/advanced/erc-4337/overview.mdx
+++ b/pages/advanced/erc-4337/overview.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../../components/CustomCard'
 
 # What is ERC-4337?
 
-[ERC-4337](../../glossary.md#erc-4337) addresses the challenges associated with account abstraction without requiring changes to the consensus-layer protocol. It serves as a transaction relayer for smart accounts like Safe. It does so by introducing a pseudo-transaction object called a `UserOperation`, which sends a transaction on behalf of the user.
+[ERC-4337](../../home/glossary.md#erc-4337) addresses the challenges associated with account abstraction without requiring changes to the consensus-layer protocol. It serves as a transaction relayer for smart accounts like Safe. It does so by introducing a pseudo-transaction object called a `UserOperation`, which sends a transaction on behalf of the user.
 
 Nodes in Ethereum can act as a Bundler, which picks up multiple user operations and packs them into a single transaction known as a bundle transaction. The bundle transactions are then sent to a global smart contract on Ethereum (of which there is only one) called the `EntryPoint`.
 

--- a/pages/home/what-is-safe.mdx
+++ b/pages/home/what-is-safe.mdx
@@ -10,9 +10,9 @@ At [Safe](https://safe.global), we pursue a future where everyone has complete c
 
 ## Smart accounts
 
-While [externally-owned accounts](../glossary.md#externally-owned-account) (EOAs) have been the cornerstone of digital assets management thus far, they have a lot of limitations and fall short in onboarding mainstream users. Not only are seed phrases cumbersome to secure, but the lack of flexibility and the limited security of EOAs hinder our progress toward actual digital ownership.
+While [externally-owned accounts](./glossary.md#externally-owned-account) (EOAs) have been the cornerstone of digital assets management thus far, they have a lot of limitations and fall short in onboarding mainstream users. Not only are seed phrases cumbersome to secure, but the lack of flexibility and the limited security of EOAs hinder our progress toward actual digital ownership.
 
-Safe is at the forefront of modular [smart account](../glossary.md#smart-account) infrastructure, paving the way for developers to create various applications and wallets. Safe brings digital ownership of accounts to everyone by building universal and open contract standards for the custody of digital assets, data, and identity.
+Safe is at the forefront of modular [smart account](./glossary.md#smart-account) infrastructure, paving the way for developers to create various applications and wallets. Safe brings digital ownership of accounts to everyone by building universal and open contract standards for the custody of digital assets, data, and identity.
 
 ## Our stack
 

--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -2,7 +2,7 @@ import { Tabs, Steps, Callout } from 'nextra/components'
 
 # Safe accounts with the Safe4337Module
 
-In this guide, you will learn how to create and execute multiple Safe transactions grouped in a batch from a Safe account that is not yet deployed and where the executor may or may not have funds to pay for the transaction fees. This can be achieved by supporting the [ERC-4337](../../../glossary.md#erc-4337) execution flow, which is supported by the [Safe4337Module](../../../advanced/erc-4337/guides/safe-sdk.mdx) and exposed via the Relay Kit from the Safe\{Core\} SDK.
+In this guide, you will learn how to create and execute multiple Safe transactions grouped in a batch from a Safe account that is not yet deployed and where the executor may or may not have funds to pay for the transaction fees. This can be achieved by supporting the [ERC-4337](../../../home/glossary.md#erc-4337) execution flow, which is supported by the [Safe4337Module](../../../advanced/erc-4337/guides/safe-sdk.mdx) and exposed via the Relay Kit from the Safe\{Core\} SDK.
 
 [Pimlico](https://pimlico.io) is used in this guide as the service provider, but any other provider compatible with the ERC-4337 can be used.
 


### PR DESCRIPTION
## Context
The Glossary page was moved to a different folder but I suspect an issue with the cache didn't highlight the broken links in the GitHub action:
- Old Glossary page (cache issue): https://docs.safe.global/glossary
- New Glossary page: https://docs.safe.global/home/glossary

This PR:
- Updates the links pointing to the Glossary with the new location.


