### PR TITLE
chore: fix broken link

### DIFF
--- a/pages/sdk/relay-kit/guides/onchain-identifier.mdx
+++ b/pages/sdk/relay-kit/guides/onchain-identifier.mdx
@@ -65,7 +65,7 @@ This guide summarizes all the steps included in the [Safe accounts with the Safe
 
   {/* <!-- vale on --> */}
 
-  If you are applying to the [Safe\{Core\} Gas Station Program](https://safe.global/gas-station), make sure to provide the value of `onchainIdentifier` in the [Gas Station form](ttps://wn2n6ocviur.typeform.com/gasstationapp) when asked.
+  If you are applying to the [Safe\{Core\} Gas Station Program](https://safe.global/gas-station), make sure to provide the value of `onchainIdentifier` in the [Gas Station form](https://wn2n6ocviur.typeform.com/gasstationapp) when asked.
 
   ### Initialize the `Safe4337Pack`
 


### PR DESCRIPTION
Hey Safe team! While preparing for a certain upcoming announcement, I stumbled across a broken link in your docs. A quick glance showed it was just missing the `h` at the beginning of `https`.

My first time contributing to the repo, so please lmk if I missed anything from the contributing guidelines.