### PR TITLE
fix: Update safe-eth-py examples package

### DIFF
--- a/pages/core-api/transaction-service-guides/data-decoder.mdx
+++ b/pages/core-api/transaction-service-guides/data-decoder.mdx
@@ -46,8 +46,8 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
     <Tabs.Tab>
       ```python
       from eth_typing import HexStr
-      from gnosis.eth import EthereumClient, EthereumNetwork
-      from gnosis.safe.api.transaction_service_api import TransactionServiceApi
+      from safe_eth.eth import EthereumClient, EthereumNetwork
+      from safe_eth.safe.api.transaction_service_api import TransactionServiceApi
       ```
     </Tabs.Tab>
   </Tabs>

--- a/pages/core-api/transaction-service-guides/delegates.mdx
+++ b/pages/core-api/transaction-service-guides/delegates.mdx
@@ -47,8 +47,8 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
     </Tabs.Tab>
     <Tabs.Tab>
       ```python
-      from gnosis.eth import EthereumClient, EthereumNetwork
-      from gnosis.safe.api.transaction_service_api import TransactionServiceApi
+      from safe_eth.eth import EthereumClient, EthereumNetwork
+      from safe_eth.safe.api.transaction_service_api import TransactionServiceApi
       from eth_account import Account
       from eth_typing import ChecksumAddress
       ```

--- a/pages/core-api/transaction-service-guides/messages.mdx
+++ b/pages/core-api/transaction-service-guides/messages.mdx
@@ -50,9 +50,9 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
       from datetime import datetime
       from eth_account import Account
       from eth_account.messages import defunct_hash_message
-      from gnosis.eth import EthereumClient, EthereumNetwork
-      from gnosis.safe import Safe
-      from gnosis.safe.api.transaction_service_api import TransactionServiceApi
+      from safe_eth.eth import EthereumClient, EthereumNetwork
+      from safe_eth.safe import Safe
+      from safe_eth.safe.api.transaction_service_api import TransactionServiceApi
       ```
     </Tabs.Tab>
   </Tabs>

--- a/pages/core-api/transaction-service-guides/transactions.mdx
+++ b/pages/core-api/transaction-service-guides/transactions.mdx
@@ -51,9 +51,9 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
     </Tabs.Tab>
     <Tabs.Tab>
       ```python
-      from gnosis.eth import EthereumClient, EthereumNetwork
-      from gnosis.safe.api.transaction_service_api import TransactionServiceApi
-      from gnosis.safe import Safe
+      from safe_eth.eth import EthereumClient, EthereumNetwork
+      from safe_eth.safe.api.transaction_service_api import TransactionServiceApi
+      from safe_eth.safe import Safe
       from hexbytes import HexBytes
       ```
     </Tabs.Tab>


### PR DESCRIPTION
Related with https://github.com/safe-global/safe-eth-py/pull/1286

Due to the update of the main `safe-eth-py` package, it is necessary to update the examples related to it.