### PR TITLE
docs: Revert Types Kit revert

### DIFF
--- a/pages/core-api/transaction-service-guides/delegates.mdx
+++ b/pages/core-api/transaction-service-guides/delegates.mdx
@@ -22,7 +22,7 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
   <Tabs items={['TypeScript', 'Python']}>
     <Tabs.Tab>
       ```bash
-      yarn add ethers @safe-global/api-kit @safe-global/protocol-kit @safe-global/safe-core-sdk-types
+      yarn add ethers @safe-global/api-kit @safe-global/protocol-kit @safe-global/types-kit
       ```
     </Tabs.Tab>
     <Tabs.Tab>

--- a/pages/core-api/transaction-service-guides/messages.mdx
+++ b/pages/core-api/transaction-service-guides/messages.mdx
@@ -22,7 +22,7 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
   <Tabs items={['TypeScript', 'Python']}>
     <Tabs.Tab>
       ```bash
-      yarn add @safe-global/api-kit @safe-global/protocol-kit @safe-global/safe-core-sdk-types
+      yarn add @safe-global/api-kit @safe-global/protocol-kit @safe-global/types-kit
       ```
     </Tabs.Tab>
     <Tabs.Tab>

--- a/pages/core-api/transaction-service-guides/transactions.mdx
+++ b/pages/core-api/transaction-service-guides/transactions.mdx
@@ -22,7 +22,7 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
   <Tabs items={['TypeScript', 'Python']}>
     <Tabs.Tab>
       ```bash
-      yarn add @safe-global/api-kit @safe-global/protocol-kit @safe-global/safe-core-sdk-types
+      yarn add @safe-global/api-kit @safe-global/protocol-kit @safe-global/types-kit
       ```
     </Tabs.Tab>
     <Tabs.Tab>
@@ -46,7 +46,7 @@ The different steps are implemented using [Curl](https://github.com/curl/curl) r
       import {
         MetaTransactionData,
         OperationType
-      } from '@safe-global/safe-core-sdk-types'
+      } from '@safe-global/types-kit'
       ```
     </Tabs.Tab>
     <Tabs.Tab>

--- a/pages/reference-sdk-api-kit/proposetransaction.mdx
+++ b/pages/reference-sdk-api-kit/proposetransaction.mdx
@@ -12,7 +12,7 @@ Creates a new multi-signature transaction with its confirmations and stores it i
   <Tabs.Tab>
     ```typescript
     import { ProposeTransactionProps } from '@safe-global/api-kit'
-    import { OperationType, SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+    import { OperationType, SafeTransactionData } from '@safe-global/types-kit'
     import { apiKit } from './setup.ts'
 
     const safeTransactionData: SafeTransactionData = {

--- a/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
+++ b/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
@@ -22,7 +22,7 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
   ```bash
   yarn add @safe-global/api-kit \
     @safe-global/protocol-kit \
-    @safe-global/safe-core-sdk-types
+    @safe-global/types-kit
   ```
 
   ### Imports
@@ -35,7 +35,7 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
   import {
     MetaTransactionData,
     OperationType
-  } from '@safe-global/safe-core-sdk-types'
+  } from '@safe-global/types-types'
   ```
 
   ### Setup

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -31,7 +31,7 @@ First, we need to install some dependencies.
 ```bash
 yarn add @safe-global/protocol-kit \
   @safe-global/api-kit \
-  @safe-global/safe-core-sdk-types
+  @safe-global/types-kit
 ```
 
 ### Initialize Signers and Providers
@@ -168,7 +168,7 @@ The high-level overview of a multi-sig transaction is PCE: Propose. Confirm. Exe
 For more details on what to include in a transaction see [`createTransaction`](./protocol-kit/reference/safe.mdx#createtransaction) method.
 
 ```tsx
-import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData } from '@safe-global/types-kit'
 
 // Any address can be used. In this example you will use vitalik.eth
 const destination = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'

--- a/pages/sdk/protocol-kit/guides/migrate-to-v4.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v4.md
@@ -2,7 +2,7 @@
 
 This guide references the major changes between v3 and v4 to help those migrating an existing app.
 
-**Note:** When upgrading to `protocol-kit` v4, it's necessary to upgrade to `safe-core-sdk-types` v5.
+**Note:** When upgrading to `protocol-kit` v4, it's necessary to upgrade to `types-kit` v1.
 
 ## The create() method was renamed init() in the SafeFactory and Safe classes
 

--- a/pages/sdk/relay-kit/guides/gelato-relay.mdx
+++ b/pages/sdk/relay-kit/guides/gelato-relay.mdx
@@ -13,7 +13,7 @@ The [Gelato relay](https://docs.gelato.network/developer-services/relay) allows 
 ## Install dependencies
 
 ```bash
-yarn add ethers @safe-global/relay-kit @safe-global/protocol-kit @safe-global/safe-core-sdk-types
+yarn add ethers @safe-global/relay-kit @safe-global/protocol-kit @safe-global/types-kit
 ```
 
 ## Relay Kit options
@@ -51,7 +51,7 @@ For the 1Balance quickstart tutorial, you will use the Gelato relayer to pay for
   import {
     MetaTransactionData,
     MetaTransactionOptions
-  } from '@safe-global/safe-core-sdk-types'
+  } from '@safe-global/types-kit'
   ```
 
   ### Initialize the transaction settings
@@ -137,7 +137,7 @@ For the SyncFee quickstart tutorial, you will use the Gelato relayer to pay for 
   import { ethers } from 'ethers'
   import { GelatoRelayPack } from '@safe-global/relay-kit'
   import Safe from '@safe-global/protocol-kit'
-  import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+  import { MetaTransactionData } from '@safe-global/types-kit'
   ```
 
   ### Initialize the transaction settings


### PR DESCRIPTION
## Context
This PR:
- Adds the `types-kit` renaming after the revert in https://github.com/safe-global/safe-docs/commit/93ce1caaea366b4c76f1d2ce5ba4867cb5736ffe