### PR TITLE
docs: Add migration guide from v4 to v5 to protocol-kit docs

### DIFF
--- a/pages/sdk/protocol-kit/guides/_meta.json
+++ b/pages/sdk/protocol-kit/guides/_meta.json
@@ -4,5 +4,6 @@
   "migrate-to-v1": "Migrate to v1",
   "migrate-to-v2": "Migrate to v2",
   "migrate-to-v3": "Migrate to v3",
-  "migrate-to-v4": "Migrate to v4"
+  "migrate-to-v4": "Migrate to v4",
+  "migrate-to-v5": "Migrate to v5"
 }

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -41,7 +41,7 @@ console.log('Safe Threshold:', await protocolKit.getThreshold())
 // new v5 code
 import Safe, { PredictedSafeProps } from '@safe-global/protocol-kit'
 
-const predictSafe: PredictedSafeProps = {
+const predictedSafe: PredictedSafeProps = {
   safeAccountConfig: {
     owners: ['0x...', '0x...', '0x...'],
     threshold: 2
@@ -55,7 +55,7 @@ const predictSafe: PredictedSafeProps = {
 let protocolKit = await Safe.init({
   provider,
   signer,
-  predictSafe
+  predictedSafe
 })
 
 // you can predict the address of your Safe if the Safe version is `v1.3.0` or above

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -1,0 +1,107 @@
+# Migrate to v5
+
+This guide references the major changes between v4 and v5 to help those migrating an existing app.
+
+## Removing `SafeFactory` class
+
+The `SafeFactory` class, previously used for deploying Safes, has been removed. The functionality to deploy Safes is now directly available in the `Safe` class through the new `createSafeDeploymentTransaction` method.
+
+### Old Method Using `SafeFactory`
+
+```typescript
+// old v4 code
+import { SafeFactory } from '@safe-global/protocol-kit'
+
+const safeFactory = await SafeFactory.init({
+   provider,
+   signer,
+   safeVersion // Optional
+})
+
+const safeAccountConfig = {
+   owners: ['0x...', '0x...', '0x...'],
+   threshold: 2
+}
+
+const protocolKit = await safeFactory.deploySafe({
+  safeAccountConfig,
+  saltNonce // Optional
+})
+
+// Confirm the Safe is deployed and fetch properties
+console.log('Is Safe deployed:', await protocolKit.isSafeDeployed());
+console.log('Safe Address:', await protocolKit.getAddress());
+console.log('Safe Owners:', await protocolKit.getOwners());
+console.log('Safe Threshold:', await protocolKit.getThreshold());
+```
+
+### New Method Using `Safe` class
+
+```typescript
+// new v5 code
+import { Safe } from '@safe-global/protocol-kit'
+
+const predictSafe = {
+  safeAccountConfig: {
+    owners: ['0x...', '0x...', '0x...'],
+    threshold: 2
+  },
+  safeDeploymentConfig: {
+    saltNonce, // Optional
+    safeVersion // Optional
+  }
+}
+
+let protocolKit = await Safe.init({
+  provider,
+  signer,
+  predictSafe
+})
+
+// you can predict the address of your Safe if the Safe version is `v1.3.0` or above
+const safeAddress = await protocolKit.getAddress()
+
+const deploymentTransaction = await protocolKit.createSafeDeploymentTransaction()
+
+// Execute this transaction using your Ethereum client
+const txHash = await client.sendTransaction({
+  to: deploymentTransaction.to,
+  value: BigInt(deploymentTransaction.value),
+  data: `0x${deploymentTransaction.data}`
+})
+
+const txReceipt = await client.waitForTransactionReceipt({ hash: txHash })
+
+// Reconnect to the newly deployed Safe using the protocol-kit
+protocolKit = await protocolKit.connect({ safeAddress })
+
+// Confirm the Safe is deployed and fetch properties
+console.log('Is Safe deployed:', await protocolKit.isSafeDeployed());
+console.log('Safe Address:', await protocolKit.getAddress());
+console.log('Safe Owners:', await protocolKit.getOwners());
+console.log('Safe Threshold:', await protocolKit.getThreshold());
+```
+
+### Predict the Safe Address
+
+Before the Safe deployment, and if you are using Safe version `v1.3.0` or above, you can predict the address of your Safe account by replacing the `SafeFactory.predictSafeAddress` method with the `Safe.getAddress` method:
+
+```typescript
+// old v4 code
+const predictedSafeAddress = await safeFactory.predictSafeAddress(
+  safeAccountConfig,
+  saltNonce  // optional
+)
+
+// new v5 code
+const predictedSafeAddress = await protocolKit.getAddress()
+```
+
+### Migration Steps
+
+- Remove any import or reference of the `SafeFactory` class from your code.
+- Replace the `SafeFactory.deploySafe` method with the `Safe.createSafeDeploymentTransaction` method where necessary. You can use your Ethereum client to execute this deployment transaction.
+- To predict the Address of your Safe Account, replace the `SafeFactory.predictSafeAddress` method with the `Safe.getAddress` method.
+- After the deployment transaction has been executed, it is necessary to reconnect the Protocol Kit instance to the newly created Safe address by using the `connect` method.
+
+The removal of `SafeFactory` means there’s one less class to initialize and manage within your project. You can now directly use the `Safe` class to handle all operations related to Safes, including their deployment.

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -76,10 +76,10 @@ const txReceipt = await client.waitForTransactionReceipt({ hash: txHash })
 protocolKit = await protocolKit.connect({ safeAddress })
 
 // Confirm the Safe is deployed and fetch properties
-console.log('Is Safe deployed:', await protocolKit.isSafeDeployed());
-console.log('Safe Address:', await protocolKit.getAddress());
-console.log('Safe Owners:', await protocolKit.getOwners());
-console.log('Safe Threshold:', await protocolKit.getThreshold());
+console.log('Is Safe deployed:', await protocolKit.isSafeDeployed())
+console.log('Safe Address:', await protocolKit.getAddress())
+console.log('Safe Owners:', await protocolKit.getOwners())
+console.log('Safe Threshold:', await protocolKit.getThreshold())
 ```
 
 ### Predict the Safe Address

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -84,7 +84,7 @@ console.log('Safe Threshold:', await protocolKit.getThreshold())
 
 ### Predict the Safe Address
 
-Before the Safe deployment, and if you are using Safe version `v1.3.0` or above, you can predict the address of your Safe account by replacing the `SafeFactory.predictSafeAddress` method with the `Safe.getAddress` method:
+You can predict the address of a Safe account before its deployment, as long as you are using Safe `v1.3.0` or greater, by replacing the `SafeFactory.predictSafeAddress` method with the `Safe.getAddress` method:
 
 ```typescript
 // old v4 code

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -10,7 +10,7 @@ The `SafeFactory` class, previously used for deploying Safes, has been removed. 
 
 ```typescript
 // old v4 code
-import { SafeFactory } from '@safe-global/protocol-kit'
+import { SafeFactory, SafeAccountConfig } from '@safe-global/protocol-kit'
 
 const safeFactory = await SafeFactory.init({
    provider,
@@ -18,7 +18,7 @@ const safeFactory = await SafeFactory.init({
    safeVersion // Optional
 })
 
-const safeAccountConfig = {
+const safeAccountConfig: SafeAccountConfig = {
    owners: ['0x...', '0x...', '0x...'],
    threshold: 2
 }
@@ -39,9 +39,9 @@ console.log('Safe Threshold:', await protocolKit.getThreshold())
 
 ```typescript
 // new v5 code
-import { Safe } from '@safe-global/protocol-kit'
+import Safe, { PredictedSafeProps } from '@safe-global/protocol-kit'
 
-const predictSafe = {
+const predictSafe: PredictedSafeProps = {
   safeAccountConfig: {
     owners: ['0x...', '0x...', '0x...'],
     threshold: 2
@@ -63,11 +63,14 @@ const safeAddress = await protocolKit.getAddress()
 
 const deploymentTransaction = await protocolKit.createSafeDeploymentTransaction()
 
-// Execute this transaction using your Ethereum client
+// Execute this transaction using the integrated signer or your preferred external Ethereum client
+const client = await protocolKit.getSafeProvider().getExternalSigner()
+
 const txHash = await client.sendTransaction({
   to: deploymentTransaction.to,
   value: BigInt(deploymentTransaction.value),
-  data: `0x${deploymentTransaction.data}`
+  data: deploymentTransaction.data as `0x${string}`,
+  chain: sepolia
 })
 
 const txReceipt = await client.waitForTransactionReceipt({ hash: txHash })

--- a/pages/sdk/protocol-kit/guides/migrate-to-v5.md
+++ b/pages/sdk/protocol-kit/guides/migrate-to-v5.md
@@ -29,10 +29,10 @@ const protocolKit = await safeFactory.deploySafe({
 })
 
 // Confirm the Safe is deployed and fetch properties
-console.log('Is Safe deployed:', await protocolKit.isSafeDeployed());
-console.log('Safe Address:', await protocolKit.getAddress());
-console.log('Safe Owners:', await protocolKit.getOwners());
-console.log('Safe Threshold:', await protocolKit.getThreshold());
+console.log('Is Safe deployed:', await protocolKit.isSafeDeployed())
+console.log('Safe Address:', await protocolKit.getAddress())
+console.log('Safe Owners:', await protocolKit.getOwners())
+console.log('Safe Threshold:', await protocolKit.getThreshold())
 ```
 
 ### New Method Using `Safe` class


### PR DESCRIPTION
Add migration guide from v4 to v5 to protocol-kit docs