### PR TITLE
docs: Update Relay Kit description

### DIFF
--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -59,7 +59,7 @@ The [API Kit](./api-kit.mdx) helps interact with the Safe Transaction Service AP
 
 ## Relay Kit
 
-The [Relay Kit](./relay-kit.mdx) enables ERC-4337 with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
+The [Relay Kit](./relay-kit.mdx) enables transaction relaying with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
 
 - Use ERC-4337 with Safe
 - Gas-less experiences using Gelato

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
-The Relay Kit enables ERC-4337 with Safe, and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or to get their transactions sponsored.
+The Relay Kit enables transaction relaying with Safe, and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or to get their transactions sponsored.
 
 <Grid item mt={3}>
   <CustomCard


### PR DESCRIPTION
## Context
Currently the Relay Kit description mentions ERC-4337 as the only transaction relaying mechanism (implicitly), but we are also supporting Gelato relay.

This PR:
- Adjusts the Relay Kit description.