### PR TITLE
chore: Update husky script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "env-cmd cypress run --headless",
     "typecheck": "tsc --noEmit --incremental false",
     "prepush": "pnpm lint && pnpm typecheck && pnpm validate-resources",
-    "prepare": "husky install",
+    "prepare": "husky",
     "release": "env-cmd release-it --no-npm --only-version"
   },
   "repository": {


### PR DESCRIPTION
## Context
`husky install` is deprecated and should be replaced with `husky`.

This PR:
- Removes the recurrent warning after every installation of the project by updating `husky` script.