### PR TITLE
docs: Add build and Entrypoint compatibility warnings

### DIFF
--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -10,7 +10,7 @@ import SafeCoreAPI from '../../assets/svg/ic-api.svg'
 The Safe\{Core\} SDK aims to bring Account Abstraction to life by integrating Safe with different third parties. This SDK helps developers to abstract the complexity of setting up a smart contract account.
 
 <Callout type="warning">
-  **Build Compatibility:** Currently, our kits are available only in CommonJS build format.
+  **Build Compatibility:** The Safe{Core} SDK kits are only available in CommonJS build format.
 </Callout>
 
 The Safe\{Core\} SDK groups its functionality into four different kits:

--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -1,3 +1,4 @@
+import { Callout } from 'nextra/components'
 import { Grid } from '@mui/material'
 import CustomCard from '../../components/CustomCard'
 import SafeCoreSDK from '../../assets/svg/ic-sdk.svg'
@@ -7,6 +8,10 @@ import SafeCoreAPI from '../../assets/svg/ic-api.svg'
 # Safe\{Core\} SDK
 
 The Safe\{Core\} SDK aims to bring Account Abstraction to life by integrating Safe with different third parties. This SDK helps developers to abstract the complexity of setting up a smart contract account.
+
+<Callout type="warning">
+  **Build Compatibility:** Currently, our kits are available only in CommonJS build format.
+</Callout>
 
 The Safe\{Core\} SDK groups its functionality into four different kits:
 

--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -3,7 +3,7 @@ import { Tabs, Steps, Callout } from 'nextra/components'
 # Safe accounts with the Safe4337Module
 
 <Callout type="warning">
-  **Supported Entrypoint Version:** Safe is currently compatible **only** with version 0.6 of the ERC 4337 Entrypoint. Version 0.7 is not supported.
+  **Supported Entrypoint Version:** Safe is currently compatible **only** with version 0.6 of the ERC 4337 Entrypoint. Version 0.7 is not supported yet.
 </Callout>
 
 In this guide, you will learn how to create and execute multiple Safe transactions grouped in a batch from a Safe account that is not yet deployed and where the executor may or may not have funds to pay for the transaction fees. This can be achieved by supporting the [ERC-4337](../../../home/glossary.md#erc-4337) execution flow, which is supported by the [Safe4337Module](../../../advanced/erc-4337/guides/safe-sdk.mdx) and exposed via the Relay Kit from the Safe\{Core\} SDK.

--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -2,6 +2,10 @@ import { Tabs, Steps, Callout } from 'nextra/components'
 
 # Safe accounts with the Safe4337Module
 
+<Callout type="warning">
+  **Supported Entrypoint Version:** Safe is currently compatible **only** with version 0.6 of the ERC 4337 Entrypoint. Version 0.7 is not supported.
+</Callout>
+
 In this guide, you will learn how to create and execute multiple Safe transactions grouped in a batch from a Safe account that is not yet deployed and where the executor may or may not have funds to pay for the transaction fees. This can be achieved by supporting the [ERC-4337](../../../home/glossary.md#erc-4337) execution flow, which is supported by the [Safe4337Module](../../../advanced/erc-4337/guides/safe-sdk.mdx) and exposed via the Relay Kit from the Safe\{Core\} SDK.
 
 Read the [Safe4337Module documentation](../../../advanced/erc-4337/guides/safe-sdk.mdx) to understand its benefits and flows better.

--- a/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
+++ b/pages/sdk/relay-kit/guides/4337-safe-sdk.mdx
@@ -3,7 +3,7 @@ import { Tabs, Steps, Callout } from 'nextra/components'
 # Safe accounts with the Safe4337Module
 
 <Callout type="warning">
-  **Supported Entrypoint Version:** Safe is currently compatible **only** with version 0.6 of the ERC 4337 Entrypoint. Version 0.7 is not supported yet.
+  **EntryPoint compatibility:**  The Relay Kit only supports the ERC-4337 EntryPoint v0.6. v0.7 is not supported yet.
 </Callout>
 
 In this guide, you will learn how to create and execute multiple Safe transactions grouped in a batch from a Safe account that is not yet deployed and where the executor may or may not have funds to pay for the transaction fees. This can be achieved by supporting the [ERC-4337](../../../home/glossary.md#erc-4337) execution flow, which is supported by the [Safe4337Module](../../../advanced/erc-4337/guides/safe-sdk.mdx) and exposed via the Relay Kit from the Safe\{Core\} SDK.


### PR DESCRIPTION
docs: Add build and Entrypoint compatibility warnings to SDK documentation

See: https://github.com/safe-global/safe-core-sdk/issues/961

![Captura de pantalla 2024-10-25 a las 12 36 03](https://github.com/user-attachments/assets/98b6b983-f7a2-46db-904a-149403e4174e)
![Captura de pantalla 2024-10-25 a las 12 39 13](https://github.com/user-attachments/assets/cc7568c7-4045-4679-b0d0-9c58e5037f70)
 