### PR TITLE
fix: formatting error causing build failure

### DIFF
--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -10,7 +10,7 @@ import SafeCoreAPI from '../../assets/svg/ic-api.svg'
 The Safe\{Core\} SDK aims to bring Account Abstraction to life by integrating Safe with different third parties. This SDK helps developers to abstract the complexity of setting up a smart contract account.
 
 <Callout type="warning">
-  **Build Compatibility:** The Safe{Core} SDK kits are only available in CommonJS build format.
+  **Build Compatibility:** The Safe\{Core\} SDK kits are only available in CommonJS build format.
 </Callout>
 
 The Safe\{Core\} SDK groups its functionality into four different kits:


### PR DESCRIPTION
Fixes formatting error from https://github.com/safe-global/safe-docs/commit/5fbf0e3317be74f9a704903e686d467237253120#diff-1271bcc4dfa052ce7e55a97453062b7a2b41fc658c475e781d880c81b48d14e5R13 that causes the build to fail.