### PR TITLE
Fix: Update broken links

### DIFF
--- a/linkchecker-config.json
+++ b/linkchecker-config.json
@@ -23,6 +23,12 @@
     },
     {
       "pattern": "^https://trustwallet.com"
+    },
+    {
+      "pattern": "^https://dashboard.pimlico.io"
+    },
+    {
+      "pattern": "^https://api.stripe.com"
     }
   ],
   "replacementPatterns": [

--- a/pages/advanced/cli-reference/unattended-commands.mdx
+++ b/pages/advanced/cli-reference/unattended-commands.mdx
@@ -1,6 +1,6 @@
 # Commands available in unattended mode
 
-In addition to the use cases referenced in the sections [Common commands for both modes](./common-commands) and [Commands specific to the tx-service mode](./tx-service-commands) it is possible to execute some commands without using the interactive prompt. This facilitates the use of `safe-cli` in generating scripts or automated processes.
+In addition to the use cases referenced in the sections [Common commands for both modes](./common-commands.mdx) and [Commands specific to the tx-service mode](./tx-service-commands.mdx) it is possible to execute some commands without using the interactive prompt. This facilitates the use of `safe-cli` in generating scripts or automated processes.
 
 The commands available for direct execution without the use of the interactive prompt are:
 

--- a/pages/advanced/erc-4337/guides/permissionless-quickstart.mdx
+++ b/pages/advanced/erc-4337/guides/permissionless-quickstart.mdx
@@ -54,7 +54,7 @@ pnpm install viem permissionless
 
   ### Setup
 
-  These are the constants that will be used in this guide. We have selected Gnosis as the chain, but other [supported networks](../supported-networks.md) can be used. We also need the Pimlico API key and a private key we will use for the owner of the Safe.
+  These are the constants that will be used in this guide. We have selected Gnosis as the chain, but other [supported networks](../../smart-account-supported-networks.mdx?module=Safe+4337+Module) can be used. We also need the Pimlico API key and a private key we will use for the owner of the Safe.
 
   {/* <!-- vale off --> */}
 

--- a/pages/advanced/passkeys/tutorials/nuxt.mdx
+++ b/pages/advanced/passkeys/tutorials/nuxt.mdx
@@ -10,7 +10,7 @@ An increasing number of applications rely on passkeys to authenticate users secu
 Being able to unlock a Safe Smart Account with your fingerprints or Face ID, sending transactions without worrying about third-party wallet interfaces, phishing attempts, or securing seed phrases will bring new forms of ownership to the connected world.
 Today, we'll learn how to make this a reality using [Safe\{Core\} SDK](../../../sdk/overview.mdx), [Pimlico](https://www.pimlico.io/), and [Nuxt](https://nuxt.com/docs/getting-started/introduction).
 
-This tutorial will demonstrate creating a web app for using [passkeys](../passkeys-overview.mdx) in your Safe. This app will allow you to:
+This tutorial will demonstrate creating a web app for using [passkeys](../overview.mdx) in your Safe. This app will allow you to:
 
 - Create a new passkey secured by the user's device.
 - Deploy a new Safe on Ethereum Sepolia for free.
@@ -41,7 +41,7 @@ When prompted by the CLI, select `pnpm` and `yes` to initialize a Git repository
 
 ### Install dependencies
 
-For this project, we'll use the [Relay Kit](../../../sdk/relay-kit.mdx) and [Protocol Kit](../../../sdk/protocol-kit.mdx) from the Safe\{Core\} SDK to set up a Safe, sponsor a transaction, and use [viem](https://www.npmjs.com/package/viem) for a helper function to encode the dummy transaction. We will also use [`@pinia/nuxt`](https://pinia.vuejs.org/) for state management and node polyfills from [Vite](https://www.npmjs.com/package/vite-plugin-node-polyfillFs).
+For this project, we'll use the [Relay Kit](../../../sdk/relay-kit.mdx) and [Protocol Kit](../../../sdk/protocol-kit.mdx) from the Safe\{Core\} SDK to set up a Safe, sponsor a transaction, and use [viem](https://www.npmjs.com/package/viem) for a helper function to encode the dummy transaction. We will also use [`@pinia/nuxt`](https://pinia.vuejs.org/) for state management and node polyfills from [Vite](https://www.npmjs.com/package/vite-plugin-node-polyfills).
 
 Run the following command to add all these dependencies to the project:
 
@@ -237,6 +237,6 @@ Please be mindful of certain security considerations when dealing with passkeys.
 
 We learned how to use passkeys (create them, store them, and use them securely) and how they can interact with a Safe (deploy it and send transactions). We hope you enjoyed this tutorial and that the combination of passkeys and the ERC-4337 will unlock new forms of ownership for your project and users.
 
-You can now integrate passkeys with more transactions and functionalities of the Safe ecosystem. You can read more about passkeys in our [overview](../passkeys-overview.mdx) or in the [WebAuthn API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
+You can now integrate passkeys with more transactions and functionalities of the Safe ecosystem. You can read more about passkeys in our [overview](../overview.mdx) or in the [WebAuthn API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
 
 Did you encounter any difficulties? Let us know by opening [an issue](https://github.com/5afe/safe-passkeys-nuxt/issues/new) or asking a question on [Stack Exchange](https://ethereum.stackexchange.com/questions/tagged/safe-core) with the `safe-core` tag.

--- a/pages/advanced/passkeys/tutorials/react.mdx
+++ b/pages/advanced/passkeys/tutorials/react.mdx
@@ -10,7 +10,7 @@ An increasing number of applications rely on passkeys to authenticate users secu
 Being able to unlock a Safe Smart Account with your fingerprints or Face ID, sending transactions without worrying about third-party wallet interfaces, phishing attempts, or securing seed phrases will bring new forms of ownership to the connected world.
 Today, we'll learn how to make this a reality using [Safe\{Core\} SDK](../../../sdk/overview.mdx), [Pimlico](https://www.pimlico.io/), and [Next.js](https://nextjs.org/docs).
 
-This tutorial will demonstrate creating a web app for using [passkeys](../passkeys-overview.mdx) in your Safe. This app will allow you to:
+This tutorial will demonstrate creating a web app for using [passkeys](../overview.mdx) in your Safe. This app will allow you to:
 
 - Create a new passkey secured by the user's device.
 - Deploy a new Safe on Ethereum Sepolia for free.
@@ -198,13 +198,13 @@ Still within the `app` folder, replace the existing content of the file `layout.
 
 In the same folder, replace the `globals.css` file with this code:
 
-```css
+```tsx
 // from ../../../../examples/passkeys/app/globals.css
 ```
 
 To add some icons to the app, we will need to edit the `next.config.mjs` file at the root of the project to load SVG files:
 
-```js
+```tsx
 // from ../../../../examples/passkeys/next.config.mjs
 ```
 
@@ -234,6 +234,6 @@ Please be mindful of certain security considerations when dealing with passkeys.
 
 We learned how to use passkeys (create them, store them, and use them securely) and how they can interact with a Safe (deploy it and send transactions). We hope you enjoyed this tutorial and that the combination of passkeys and the ERC-4337 will unlock new forms of ownership for your project and users.
 
-You can now integrate passkeys with more transactions and functionalities of the Safe ecosystem. You can read more about passkeys in our [overview](../passkeys-overview.mdx) or in the [WebAuthn API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
+You can now integrate passkeys with more transactions and functionalities of the Safe ecosystem. You can read more about passkeys in our [overview](../overview.mdx) or in the [WebAuthn API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
 
 Did you encounter any difficulties? Let us know by opening [an issue](https://github.com/5afe/safe-passkeys-tutorial/issues/new) or asking a question on [Stack Exchange](https://ethereum.stackexchange.com/questions/tagged/safe-core) with the `safe-core` tag.

--- a/pages/advanced/smart-account-bug-bounty.md
+++ b/pages/advanced/smart-account-bug-bounty.md
@@ -41,7 +41,7 @@ The scope of the bug bounty also includes officially supported Safe Modules:
 * MultiSend.sol, MultiSendCallOnly.sol, CreateCall.sol
 * TokenCallbackHandler.sol (formerly DefaultCallbackHandler.sol), CompatibilityFallbackHandler.sol, HandlerContext.sol
 
-You can find addresses for deployed instances of these contracts [here](/advanced/smart-account-supported-networks?version=v1.4.1) or in the [Safe deployments](https://github.com/safe-global/safe-deployments) repository.
+You can find addresses for deployed instances of these contracts [here](./smart-account-supported-networks.mdx?version=v1.4.1) or in the [Safe deployments](https://github.com/safe-global/safe-deployments) repository.
 
 **Gnosis Safe core contracts (up to version 1.3.0)**
 
@@ -52,7 +52,7 @@ You can find addresses for deployed instances of these contracts [here](/advance
 * CreateAndAddModules.sol, MultiSend.sol, MultiSendCallOnly.sol, CreateCall.sol
 * DefaultCallbackHandler.sol, CompatibilityFallbackHandler.sol, HandlerContext.sol
 
-You can find addresses for deployed instances of these contracts [here](/advanced/smart-account-supported-networks?version=v1.3.0) in the [Safe deployments](https://github.com/safe-global/safe-deployments) repository.
+You can find addresses for deployed instances of these contracts [here](./smart-account-supported-networks.mdx?version=v1.3.0) in the [Safe deployments](https://github.com/safe-global/safe-deployments) repository.
 
 **Safe Modules contracts**
 

--- a/pages/home/glossary.md
+++ b/pages/home/glossary.md
@@ -155,7 +155,7 @@ A Safe Guard is a smart contract that adds restrictions on top of the n-out-of-m
 See also:
 - [Safe Guards documentation](../advanced/smart-account-guards.mdx) on docs.safe.global
 - [Zodiac Guards](https://zodiac.wiki/index.php%3Ftitle=Introduction:_Zodiac_Protocol.html#Guards) on zodiac.wiki
-- [Get the enabled Safe Guard](../sdk/protocol-kit/reference.md#getguard) and [enable a Safe Guard](../sdk/protocol-kit/reference.md#createenableguardtx) with the Safe{Core} SDK on docs.safe.global
+- [Get the enabled Safe Guard](../reference-sdk-protocol-kit/safe-guards/getguard.mdx) and [enable a Safe Guard](../reference-sdk-protocol-kit/safe-guards/createenableguardtx.mdx) with the Safe{Core} SDK on docs.safe.global
 
 ## Safe Module
 
@@ -165,7 +165,7 @@ See also:
 - [Safe Modules documentation](../advanced/smart-account-modules.mdx) on docs.safe.global
 - [Safe Modules repository](https://github.com/safe-global/safe-modules) on github.com
 - [Zodiac Modules](https://zodiac.wiki/index.php%3Ftitle=Introduction:_Zodiac_Protocol.html#Modules) on zodiac.wiki
-- [Get the enabled Safe Modules](../sdk/protocol-kit/reference.md#getmodules) and [enable a Safe Module](../sdk/protocol-kit/reference.md#createenablemoduletx) with the Safe{Core} SDK on docs.safe.global
+- [Get the enabled Safe Modules](../reference-sdk-protocol-kit/safe-modules/getmodules.mdx) and [enable a Safe Module](../reference-sdk-protocol-kit/safe-modules/createenablemoduletx.mdx) with the Safe\{Core\} SDK on docs.safe.global
 
 ## Smart Account
 
@@ -193,7 +193,7 @@ See also:
 The threshold of a Safe account is a crucial configuration element that enables using Safe as a multi-signature smart account. It defines the number of required confirmations from the Safe owners a (Safe) transaction must have to be executable.
 
 See also:
-- [Get the threshold](../sdk/protocol-kit/reference.md#getthreshold) and [change the threshold](../sdk/protocol-kit/reference.md#createchangethresholdtx) of a Safe with the Safe{Core} SDK on docs.safe.global
+- [Get the threshold](../reference-sdk-protocol-kit/safe-info/getthreshold.mdx) and [change the threshold](../reference-sdk-protocol-kit/safe-info/createchangethresholdtx.mdx) of a Safe with the Safe{Core} SDK on docs.safe.global
 
 ## UserOperation
 

--- a/pages/home/safe-core.mdx
+++ b/pages/home/safe-core.mdx
@@ -67,4 +67,4 @@ The Safe\{Core\} stack is categorized into three distinct groups:
 
 ## Getting started
 
-Are you new to Safe and not sure where to get started? We recommend heading over to one of our [tutorials](/resource-hub?source=Safe+Team&tag=Tutorial).
+Are you new to Safe and not sure where to get started? We recommend heading over to one of our [tutorials](../resource-hub.mdx?source=Safe+Team&tag=Tutorial).

--- a/pages/reference-sdk-api-kit/overview.mdx
+++ b/pages/reference-sdk-api-kit/overview.mdx
@@ -1,6 +1,6 @@
 # API Kit Reference
 
-The [API Kit](../sdk/api-kit.mdx) facilitates the interaction with the [Safe Transaction Service API](../core-api/transaction-service-overview).
+The [API Kit](../sdk/api-kit.mdx) facilitates the interaction with the [Safe Transaction Service API](../core-api/transaction-service-overview.mdx).
 
 ## Install dependencies
 

--- a/pages/reference-sdk-react-hooks/useconfirmtransaction.mdx
+++ b/pages/reference-sdk-react-hooks/useconfirmtransaction.mdx
@@ -122,8 +122,8 @@ The configuration used instead of the one from the nearest [`SafeProvider`](./sa
 import { UseConfirmTransactionReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
-
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
+                                        
 ### `confirmTransaction`
 
 - **Type**: `UseMutateFunction<SafeClientResult, Error, ConfirmTransactionVariables, unknown>`

--- a/pages/reference-sdk-react-hooks/useconfirmtransaction.mdx
+++ b/pages/reference-sdk-react-hooks/useconfirmtransaction.mdx
@@ -123,7 +123,6 @@ import { UseConfirmTransactionReturnType } from '@safe-global/safe-react-hooks'
 ```
 
 [TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
-                                        
 ### `confirmTransaction`
 
 - **Type**: `UseMutateFunction<SafeClientResult, Error, ConfirmTransactionVariables, unknown>`

--- a/pages/reference-sdk-react-hooks/usesendtransaction.mdx
+++ b/pages/reference-sdk-react-hooks/usesendtransaction.mdx
@@ -125,7 +125,7 @@ The configuration used instead of the one from the nearest [`SafeProvider`](./sa
 import { UseSendTransactionReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
 
 ### `sendTransaction`
 

--- a/pages/reference-sdk-react-hooks/useupdateowners/add.mdx
+++ b/pages/reference-sdk-react-hooks/useupdateowners/add.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components"
 
 # `add`
 
-Contains the `addOwner` and `addOwnerAsync` functions, which execute a Safe transaction to add a new owner to the Safe connected to the [`SafeProvider`](./safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
+Contains the `addOwner` and `addOwnerAsync` functions, which execute a Safe transaction to add a new owner to the Safe connected to the [`SafeProvider`](../safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
 
 ## Usage
 
@@ -79,7 +79,7 @@ The connected Safe must be already deployed.
 import { UseAddOwnerReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
 
 ### `addOwner`
 

--- a/pages/reference-sdk-react-hooks/useupdateowners/remove.mdx
+++ b/pages/reference-sdk-react-hooks/useupdateowners/remove.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components"
 
 # `remove`
 
-Contains the `removeOwner` and `removeOwnerAsync` functions, which execute a Safe transaction to remove an owner of the Safe connected to the [`SafeProvider`](./safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
+Contains the `removeOwner` and `removeOwnerAsync` functions, which execute a Safe transaction to remove an owner of the Safe connected to the [`SafeProvider`](../safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
 
 ## Usage
 
@@ -79,7 +79,7 @@ The connected Safe must be already deployed.
 import { UseRemoveOwnerReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
 
 ### `removeOwner`
 

--- a/pages/reference-sdk-react-hooks/useupdateowners/swap.mdx
+++ b/pages/reference-sdk-react-hooks/useupdateowners/swap.mdx
@@ -2,7 +2,7 @@ import { Tabs } from "nextra/components"
 
 # `swap`
 
-Contains the `swapOwner` and `swapOwnerAsync` functions, which execute a Safe transaction to swap an owner of the Safe connected to the [`SafeProvider`](./safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
+Contains the `swapOwner` and `swapOwnerAsync` functions, which execute a Safe transaction to swap an owner of the Safe connected to the [`SafeProvider`](../safeprovider.mdx) or send it to the Safe Transaction Service if it isn't executable.
 
 ## Usage
 
@@ -79,7 +79,7 @@ The connected Safe must be already deployed.
 import { UseSwapOwnerReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
 
 ### `swapOwner`
 

--- a/pages/reference-sdk-react-hooks/useupdatethreshold.mdx
+++ b/pages/reference-sdk-react-hooks/useupdatethreshold.mdx
@@ -122,7 +122,7 @@ The configuration used instead of the one from the nearest [`SafeProvider`](./sa
 import { UseUpdateThresholdReturnType } from '@safe-global/safe-react-hooks'
 ```
 
-[TanStack Query mutation documentation](https://tanstack.com/mutation/v5/docs/framework/react/reference/useMutation).
+[TanStack Query mutation documentation](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation).
 
 ### `updateThreshold`
 

--- a/pages/reference-sdk-starter-kit/safe-client/constructor.mdx
+++ b/pages/reference-sdk-starter-kit/safe-client/constructor.mdx
@@ -4,7 +4,7 @@ import { Tabs } from 'nextra/components'
 
 Returns an instance of the `SafeClient` class, which enables developers to configure new or existing Safe accounts and handle transactions.
 
-The `SafeClient` class provides a mechanism to extend its functionality via the [`extend`](./extend) method.
+The `SafeClient` class provides a mechanism to extend its functionality via the [`extend`](./extend.mdx) method.
 
 ## Usage
 

--- a/pages/sdk/api-kit.mdx
+++ b/pages/sdk/api-kit.mdx
@@ -3,7 +3,7 @@ import CustomCard from '../../components/CustomCard'
 
 # API Kit
 
-The API Kit facilitates the interaction with the [Safe Transaction Service API](../core-api/transaction-service-overview), allowing to propose and share transactions with the other signers of a Safe, sending the signatures to the service to collect them, getting information about a Safe (like reading the transaction history, pending transactions, enabled Modules and Guards, etc.), among other features.
+The API Kit facilitates the interaction with the [Safe Transaction Service API](../core-api/transaction-service-overview.mdx), allowing to propose and share transactions with the other signers of a Safe, sending the signatures to the service to collect them, getting information about a Safe (like reading the transaction history, pending transactions, enabled Modules and Guards, etc.), among other features.
 
 <Grid item mt={3}>
   <CustomCard

--- a/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
+++ b/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
@@ -89,7 +89,7 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
 
   Before a transaction can be executed, any of the Safe signers needs to initiate the process by creating a proposal of a transaction. This transaction is sent to the service to make it accessible by the other owners so they can give their approval and sign the transaction as well.
 
-  For a full list and description of the properties see [`proposeTransaction`](../../../reference-sdk-api-kit/proposetransaction) in the API Kit reference.
+  For a full list and description of the properties see [`proposeTransaction`](../../../reference-sdk-api-kit/proposetransaction.mdx) in the API Kit reference.
 
   ```typescript
   // Create transaction
@@ -132,7 +132,7 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
 
   ### Confirm the transaction
 
-  In this step you need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the [`confirmTransaction`](../../../reference-sdk-api-kit/confirmtransaction) method.
+  In this step you need to sign the transaction with the Protocol Kit and submit the signature to the Safe Transaction Service using the [`confirmTransaction`](../../../reference-sdk-api-kit/confirmtransaction.mdx) method.
 
   ```typescript
   const protocolKitOwner2 = await Safe.init({
@@ -151,6 +151,6 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
   )
   ```
 
-  The Safe transaction is now ready to be executed. This can be done using the [Safe\{Wallet\} web](https://app.safe.global) interface, the [Protocol Kit](../../protocol-kit/reference/safe#executetransaction), the [Safe CLI](../../../advanced/cli-reference/tx-service-commands#execute-pending-transaction) or any other tool that's available.
+  The Safe transaction is now ready to be executed. This can be done using the [Safe\{Wallet\} web](https://app.safe.global) interface, the [Protocol Kit](../../../reference-sdk-protocol-kit/transactions/executetransaction.mdx), the [Safe CLI](../../../advanced/cli-reference/tx-service-commands.mdx#execute-pending-transaction) or any other tool that's available.
 
 </Steps>

--- a/pages/sdk/onramp/monerium.mdx
+++ b/pages/sdk/onramp/monerium.mdx
@@ -15,7 +15,7 @@ This guide demonstrates how to use the [Monerium SDK](https://monerium.github.io
 1. [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 2. [Monerium account and application](https://monerium.dev/docs/getting-started/create-app)
 3. A web application using your favorite CLI and language. For example [React with NextJS](https://nextjs.org/docs), [Vue with Nuxt](https://nuxt.com/) or [Svelte with SvelteKit](https://kit.svelte.dev/).
-4. A [deployed Safe](../../../sdk/protocol-kit.mdx) for your users.
+4. A [deployed Safe](../protocol-kit.mdx) for your users.
 
 ## Overview
 
@@ -92,8 +92,8 @@ const transactionResult = await protocolKitOfOwner2.executeTransaction(
 console.log('transactionResult', transactionResult)
 ```
 
-The `protocolKit` is an instance of the [`Safe`](../protocol-kit/reference/safe.mdx) class. 
-For more information on instantiating the `protocol-kit,` refer to the [Protocol Kit Quickstart section](../protocol-kit.mdx).
+The `protocolKit` is an instance of the [`Safe`](../../reference-sdk-protocol-kit/initialization/init.mdx) class. 
+For more information on instantiating the Protocol Kit, refer to the [Protocol Kit Quickstart section](../protocol-kit.mdx).
 
 ### Initialize the Monerium client and authenticate the users
 

--- a/pages/sdk/onramp/stripe.mdx
+++ b/pages/sdk/onramp/stripe.mdx
@@ -16,7 +16,7 @@ The [Stripe fiat-to-crypto onramp service](https://docs.stripe.com/crypto/onramp
 1. [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 2. [Stripe account](https://dashboard.stripe.com/register)
 3. A web application using your favorite CLI and language. For example [React with NextJS](https://nextjs.org/docs), [Vue with Nuxt](https://nuxt.com/) or [Svelte with SvelteKit](https://kit.svelte.dev/).
-4. A [deployed Safe](../../../sdk/protocol-kit.mdx) for your users.
+4. A [deployed Safe](../protocol-kit.mdx) for your users.
 
 ## Integrate the Stripe fiat-to-crypto onramp widget
 

--- a/pages/sdk/protocol-kit.mdx
+++ b/pages/sdk/protocol-kit.mdx
@@ -14,9 +14,9 @@ The Protocol Kit enables developers to interact with [Safe Smart Accounts](https
 </Grid>
 
 The following guides show how to use the Protocol Kit and integrate it into your project:
-- [Execute transactions](./protocol-kit/guides/execute-transactions)
-- [Transactions signatures](./protocol-kit/guides/signatures/transactions)
-- [Message signatures](./protocol-kit/guides/signatures/messages)
+- [Execute transactions](./protocol-kit/guides/execute-transactions.mdx)
+- [Transactions signatures](./protocol-kit/guides/signatures/transactions.mdx)
+- [Message signatures](./protocol-kit/guides/signatures/messages.mdx)
 
 ## Resources
 

--- a/pages/sdk/protocol-kit/guides/execute-transactions.mdx
+++ b/pages/sdk/protocol-kit/guides/execute-transactions.mdx
@@ -2,7 +2,7 @@
 
 In this quickstart guide, you will create a 2 of 3 multi-sig Safe and propose and execute a transaction to send some ETH out of this Safe.
 
-To find more details and configuration options for available methods, see the [Protocol Kit reference](./protocol-kit/reference).
+To find more details and configuration options for available methods, see the [Protocol Kit reference](../../../reference-sdk-protocol-kit/overview.md).
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ const owner1Signer = new ethers.Wallet(OWNER_1_PRIVATE_KEY, provider)
 
 The [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit) consumes the [Safe Transaction Service API](https://github.com/safe-global/safe-transaction-service). To use this library, create a new instance of the `SafeApiKit` class, imported from `@safe-global/api-kit`. In chains where Safe provides a Transaction Service, it's enough to specify the `chainId.` You can specify your own service using the optional `txServiceUrl` parameter.
 
-You will be using Sepolia for this tutorial, however, you can also get [service URLs for different networks](../core-api/transaction-service-supported-networks.md).
+You will be using Sepolia for this tutorial, however, you can also get [service URLs for different networks](../../../advanced/smart-account-supported-networks.mdx?service=Transaction+Service&service=Safe{Core}+SDK).
 
 ```tsx
 import SafeApiKit from '@safe-global/api-kit'
@@ -149,7 +149,7 @@ The high-level overview of a multi-sig transaction is PCE: Propose. Confirm. Exe
 
 ### Create a transaction
 
-For more details on what to include in a transaction see [`createTransaction`](./protocol-kit/reference/safe.mdx#createtransaction) method.
+For more details on what to include in a transaction see [`createTransaction`](../../../reference-sdk-protocol-kit/transactions/createtransaction.mdx) method.
 
 ```tsx
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
@@ -203,7 +203,7 @@ safeTransaction.data.data = concat([
 
 To propose a transaction to the Safe Transaction Service we need to call the `proposeTransaction` method from the API Kit instance.
 
-For a full list and description of the properties see [`proposeTransaction`](../reference-sdk-api-kit/proposetransaction) in the API Kit reference.
+For a full list and description of the properties see [`proposeTransaction`](../../../reference-sdk-api-kit/proposetransaction.mdx) in the API Kit reference.
 
 ```tsx
 // Deterministic hash based on transaction parameters
@@ -222,8 +222,6 @@ await apiKit.proposeTransaction({
 ```
 
 ### Get pending transactions
-
-Recall that you created the `apiKit` in [Initialize the API Kit](./protocol-kit/#initialize-the-api-kit).
 
 ```tsx
 const pendingTransactions = (await apiKit.getPendingTransactions(safeAddress)).results

--- a/pages/sdk/react-hooks.mdx
+++ b/pages/sdk/react-hooks.mdx
@@ -16,7 +16,7 @@ These hooks are built on top of the [Starter Kit](./starter-kit.mdx), which leve
 </Grid>
 
 The following guides show how to use the Safe React Hooks and integrate it into your project:
-- [Send transactions](./react-hooks/guides/send-transactions)
+- [Send transactions](./react-hooks/guides/send-transactions.mdx)
 
 ## Resources
 

--- a/pages/sdk/starter-kit.mdx
+++ b/pages/sdk/starter-kit.mdx
@@ -20,8 +20,8 @@ The Starter Kit is built on top of several kits from the Safe\{Core\} SDK, lever
 </Grid>
 
 The following guides show how to use the Starter Kit and integrate it into your project:
-- [Send transactions](./starter-kit/guides/send-transactions)
-- [Send user operations](./starter-kit/guides/send-user-operations)
+- [Send transactions](./starter-kit/guides/send-transactions.mdx)
+- [Send user operations](./starter-kit/guides/send-user-operations.mdx)
 
 ## Resources
 

--- a/pages/sdk/starter-kit/guides/send-user-operations.mdx
+++ b/pages/sdk/starter-kit/guides/send-user-operations.mdx
@@ -2,7 +2,7 @@ import { Steps, Tabs } from 'nextra/components'
 
 # Send User Operations
 
-In this guide, you will learn how to create Safe [user operations](../../../home/glossary.mdx#useroperation), sign them, collect the signatures from the different owners, and execute them.
+In this guide, you will learn how to create Safe [user operations](../../../home/glossary.md#useroperation), sign them, collect the signatures from the different owners, and execute them.
 
 For more detailed information, see the [Starter Kit Reference](../../../reference-sdk-starter-kit/overview.mdx).
 


### PR DESCRIPTION
## Context
This PR:
- Fixes broken links in the docs.

Note:
- There is a broken link in the Protocol Kit guide. This is expected and can't be fixed at this point as it is pointing to a method that no longer exists in the Protocol Kit reference. It will be fixed/replaced when the new Protocol Kit guide is live.