### PR TITLE
docs: change default value and add description to operation type at createTransaction

### DIFF
--- a/pages/reference-sdk-protocol-kit/transactions/createtransaction.mdx
+++ b/pages/reference-sdk-protocol-kit/transactions/createtransaction.mdx
@@ -108,9 +108,9 @@ const safeTransaction = await protocolKit.createTransaction({
 ### `transactions.operation` (Optional)
 
 - **Type:** `OperationType`
-- **Default:** `1`
+- **Default:** `0`
 
-The operation of the Safe transaction.
+The operation of the Safe transaction. `0` for a *Call* and `1` for a *DelegateCall*.
 
 ```typescript focus=6
 const safeTransaction = await protocolKit.createTransaction({


### PR DESCRIPTION
* Fixes default value of operationType at the `createTransaction` reference.
* Adds a sentence to describe the two possible values.