### PR TITLE
Fix sdk name on send-transactions.mdx

### DIFF
--- a/pages/sdk/starter-kit/guides/send-transactions.mdx
+++ b/pages/sdk/starter-kit/guides/send-transactions.mdx
@@ -15,7 +15,7 @@ For more detailed information, see the [Starter Kit Reference](../../../referenc
 First, you need to install some dependencies.
 
 ```bash
-pnpm add @safe-global/starter-kit
+pnpm add @safe-global/sdk-starter-kit
 ```
 
 ## Steps


### PR DESCRIPTION
The installation command fails because the library name is incomplete.