### PR TITLE
docs: fix typo in `@safe-global/types-kit`

### DIFF
--- a/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
+++ b/pages/sdk/api-kit/guides/propose-and-confirm-transactions.mdx
@@ -35,7 +35,7 @@ For more detailed information, see the [API Kit Reference](../../../reference-sd
   import {
     MetaTransactionData,
     OperationType
-  } from '@safe-global/types-types'
+  } from '@safe-global/types-kit'
   ```
 
   ### Setup


### PR DESCRIPTION
Fix a typo in the imported package in this page https://docs.safe.global/sdk/api-kit/guides/propose-and-confirm-transactions#imports