### PR TITLE
fix: Add missing parameters in `Safe.setup()`

### DIFF
--- a/pages/reference-smart-account/setup/setup.mdx
+++ b/pages/reference-smart-account/setup/setup.mdx
@@ -151,7 +151,7 @@ Handler for fallback calls to this contract.
 
 - **Type:** `address`
 
-Token that should be used for the payment (0 is ETH).
+Token contract address used for the payment of the Safe proxy contract deployment fees (`0` is the native token).
 
 ```solidity focus=7
 (ISafe safe).setup(

--- a/pages/reference-smart-account/setup/setup.mdx
+++ b/pages/reference-smart-account/setup/setup.mdx
@@ -20,13 +20,28 @@ Sets an initial storage of the Safe contract.
     interface ISafe {
         function setup(
             address[] _owners,
-            uint256 _threshold
+            uint256 _threshold,
+            address to,
+            bytes data,
+            address fallbackHandler,
+            address paymentToken,
+            uint256 payment,
+            address payable paymentReceiver
         ) external;
     }
 
     contract Example {
       function example() ... {
-          (ISafe safe).setup([0x..., 0x...], 1);
+          (ISafe safe).setup(
+            [0x..., 0x...],
+            1,
+            0x...,
+            "0x...",
+            0x...,
+            0x...,
+            0,
+            0x...
+          );
       }
     }
     ```
@@ -46,7 +61,13 @@ List of Safe owners.
 ```solidity focus=2
 (ISafe safe).setup(
     [0x..., 0x...],
-    1
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
 );
 ```
 
@@ -59,7 +80,127 @@ Number of required confirmations for a Safe transaction.
 ```solidity focus=3
 (ISafe safe).setup(
     [0x..., 0x...],
-    1
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `to`
+
+- **Type:** `address`
+
+Contract address for optional delegate call.
+
+```solidity focus=4
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `data`
+
+- **Type:** `bytes`
+
+Data payload for optional delegate call.
+
+```solidity focus=5
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `fallbackHandler`
+
+- **Type:** `address`
+
+Handler for fallback calls to this contract.
+
+```solidity focus=6
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `paymentToken`
+
+- **Type:** `address`
+
+Token that should be used for the payment (0 is ETH).
+
+```solidity focus=7
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `payment`
+
+- **Type:** `uint256`
+
+Value that should be paid.
+
+```solidity focus=8
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
+);
+```
+
+### `paymentReceiver`
+
+- **Type:** `address`
+
+Address that should receive the payment (or 0 if `tx.origin`).
+
+```solidity focus=9
+(ISafe safe).setup(
+    [0x..., 0x...],
+    1,
+    0x...,
+    "0x...",
+    0x...,
+    0x...,
+    0,
+    0x...
 );
 ```
 

--- a/pages/reference-smart-account/setup/setup.mdx
+++ b/pages/reference-smart-account/setup/setup.mdx
@@ -94,7 +94,7 @@ Number of required confirmations for a Safe transaction.
 
 - **Type:** `address`
 
-Contract address for optional delegate call.
+Contract address used as the destination of an optional delegate call.
 
 ```solidity focus=4
 (ISafe safe).setup(

--- a/pages/reference-smart-account/setup/setup.mdx
+++ b/pages/reference-smart-account/setup/setup.mdx
@@ -170,7 +170,7 @@ Token that should be used for the payment (0 is ETH).
 
 - **Type:** `uint256`
 
-Value that should be paid.
+Amount of `paymentToken` to be paid for the Safe proxy contract deployment fees.
 
 ```solidity focus=8
 (ISafe safe).setup(

--- a/pages/reference-smart-account/setup/setup.mdx
+++ b/pages/reference-smart-account/setup/setup.mdx
@@ -189,7 +189,7 @@ Value that should be paid.
 
 - **Type:** `address`
 
-Address that should receive the payment (or 0 if `tx.origin`).
+Address that receives the payment for the Safe proxy contract deployment fees (or `0` if `tx.origin`).
 
 ```solidity focus=9
 (ISafe safe).setup(


### PR DESCRIPTION
This PR adds parameters that were missing from the Smart Account Reference page for `Safe.setup()`: `to`, `data`, `fallbackHandler`, `paymentToken`, `payment` and `paymentReceiver`.