### PR TITLE
Highlight Safe network deployments

### DIFF
--- a/components/SupportedNetworks/Networks.tsx
+++ b/components/SupportedNetworks/Networks.tsx
@@ -271,7 +271,7 @@ const SupportedNetworks: React.FC = () => {
   const sidebar = (
     <>
       <NextLink
-        href='/core-api/safe-contracts-deployment'
+        href='/core-api/safe-installation-overview'
         target='_blank'
         rel='noreferrer'
       >

--- a/pages/core-api/safe-contracts-deployment.mdx
+++ b/pages/core-api/safe-contracts-deployment.mdx
@@ -4,6 +4,10 @@ import { Callout, Steps, Tabs, Tab } from 'nextra/components'
 
 In this section, you will deploy the Safe\{Core\} contracts on your chain. All Safe contract deployments on any network follow the same procedure to ensure a deterministic address for all singleton contracts (proxy-factory, mastercopy, etc.) and verify the deployment.
 
+<Callout type="info" emoji="ℹ️">
+  You can also use the [Platform-as-a-Service deployment run by Safe Core Contributors](https://noteforms.com/forms/request-safe-ui-and-infra-support-4weugt) or third-party integrators.
+</Callout>
+
 ## Prerequisites
 
 Open a [pull request](https://github.com/ethereum-lists/chains) to add your chain to [chainlist.org](https://chainlist.org/).

--- a/pages/core-api/safe-infrastructure-deployment.mdx
+++ b/pages/core-api/safe-infrastructure-deployment.mdx
@@ -10,8 +10,9 @@ You have three options for deploying the Safe stack, depending on your needs.
 
 We roll out new networks quarterly, depending on our internal capacity, and only for medium to large chains based on a strict scoring framework. 
 
-If you want to submit your chain for assessment in the next quarter, please fill out this [form](https://noteforms.com/forms/request-safe-ui-and-infra-support-4weugt).
-
+<Callout type="info" emoji="ℹ️">
+    If you want to submit your chain for assessment in the next quarter, please fill out this [form](https://noteforms.com/forms/request-safe-ui-and-infra-support-4weugt).
+</Callout>
 ### Hard requirements
 
 - EVM-compatible chain.

--- a/pages/core-api/safe-installation-overview.mdx
+++ b/pages/core-api/safe-installation-overview.mdx
@@ -29,7 +29,7 @@ Safe reviews registrations of canonical deployments on a two-week cadence.
 
 You have three options available:
 
-1. Use the Platform-as-a-Service run by Safe Core Contributors.
+1. [Use the Platform-as-a-Service run by Safe Core Contributors](https://noteforms.com/forms/request-safe-ui-and-infra-support-4weugt).
 2. Use the Platform-as-a-Service run by third-party integrators.
 3. Self-host the infrastructure.
 


### PR DESCRIPTION
The goal of this PR is to highlight the application form link for Safe network deployments.

Changes:
- add callouts with the form link
- add link to the PaaS with Safe
- redirect to the overview of Safe deployments from the supported networks page