### PR TITLE
Fix typo Update generated-reference.mdx

### DIFF
--- a/components/ApiReference/generated-reference.mdx
+++ b/components/ApiReference/generated-reference.mdx
@@ -603,7 +603,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-tra
 
     
 
-    Removes the queued but not executed multi-signature transaction associated with the given Safe tansaction hash.
+    Removes the queued but not executed multi-signature transaction associated with the given Safe transaction hash.
 Only the proposer or the delegate who proposed the transaction can delete it.
 If the transaction was proposed by a delegate, it must still be a valid delegate for the transaction proposer.
 An EOA is required to sign the following EIP-712 data:


### PR DESCRIPTION
Original: "associated with the given Safe tansaction hash."
Corrected: "associated with the given Safe transaction hash."
This fix improves the accuracy and readability of the document by correcting the misspelling.