### PR TITLE
Fix API sample responses and request parameters

### DIFF
--- a/.github/scripts/generateApiReference.ts
+++ b/.github/scripts/generateApiReference.ts
@@ -288,7 +288,7 @@ const generateMethodContent = (path: string, method: string) => {
       method.toUpperCase()
   const filePath = `./components/ApiReference/examples/${slugify(
     path
-  )}-${method}`
+  )}-${method}`.replace('-api', '')
   const examplePath = filePath + '.ts'
   const sampleResponsePath = filePath + '.json'
   const hasExample = fs.existsSync(examplePath)
@@ -365,7 +365,7 @@ ${curlify({
           hasExample && example !== 'export {}\n'
             ? `
 \`\`\`js TypeScript
-// from ./examples/${slugify(path)}-${method}.ts
+// from ${examplePath.replace('./components/ApiReference/', '')}
 \`\`\`
             `
             : ''

--- a/.github/scripts/generateApiReference.ts
+++ b/.github/scripts/generateApiReference.ts
@@ -353,6 +353,15 @@ const generateMethodContent = (path: string, method: string) => {
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+${
+  hasExample && example !== 'export {}\n'
+    ? `
+\`\`\`js TypeScript
+// from ${examplePath.replace('./components/ApiReference/', '')}
+\`\`\`
+            `
+    : ''
+}
 \`\`\`bash ${hasExample && example !== 'export {}\n' ? 'curl' : ''}
 ${curlify({
   url: pathWithParams,
@@ -360,16 +369,6 @@ ${curlify({
   body: requestBody
 })} 
 \`\`\`
-
-        ${
-          hasExample && example !== 'export {}\n'
-            ? `
-\`\`\`js TypeScript
-// from ${examplePath.replace('./components/ApiReference/', '')}
-\`\`\`
-            `
-            : ''
-        }
       </CH.Code>
     </CH.Section>
     <NetworkNotice />

--- a/components/ApiReference/Property.tsx
+++ b/components/ApiReference/Property.tsx
@@ -94,7 +94,9 @@ const Property: React.FC<{ property: any; required?: boolean }> = ({
                 ? '[]'
                 : property.value?.type === 'object'
                   ? ''
-                  : property.value?.type}
+                  : Array.isArray(property.value?.type)
+                    ? property.value?.type.join(' | ')
+                    : (property.value?.type ?? property.value.schema?.type)}
             </code>
             <Typography
               variant='body1'

--- a/components/ApiReference/Property.tsx
+++ b/components/ApiReference/Property.tsx
@@ -96,7 +96,10 @@ const Property: React.FC<{ property: any; required?: boolean }> = ({
                   ? ''
                   : Array.isArray(property.value?.type)
                     ? property.value?.type.join(' | ')
-                    : (property.value?.type ?? property.value.schema?.type)}
+                    : (property.value?.type ??
+                      (Array.isArray(property.value.schema?.type)
+                        ? property.value.schema?.type.join(' | ')
+                        : property.value.schema?.type))}
             </code>
             <Typography
               variant='body1'

--- a/components/ApiReference/generated-reference.mdx
+++ b/components/ApiReference/generated-reference.mdx
@@ -46,14 +46,13 @@ This service is available on [multiple networks](../../core-api/transaction-serv
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/contracts/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -123,14 +122,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/contracts/ \
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/contracts/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -190,18 +188,17 @@ as in case of an ABI collision the Safe Transaction Service would know which ABI
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-data-decoder--post.ts
+```
+            
 ```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/data-decoder/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-data-decoder--post.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -261,18 +258,17 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/data-decode
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v2-delegates--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v2-delegates--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -355,18 +351,17 @@ Unix UTC epoch time (no milliseconds) and dividing by 3600 (natural division, no
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v2-delegates--post.ts
+```
+            
 ```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v2-delegates--post.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -408,18 +403,17 @@ either the `delegator` (owner) or the `delegate` itself. Check `POST /delegates/
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v2-delegates-{delegate_address}--delete.ts
+```
+            
 ```bash curl
 curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/0xe8A11B18DA0C02ce6304347D8E0DA66C50dEf739/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
-```js TypeScript
-// from examples/-v2-delegates-{delegate_address}--delete.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -465,18 +459,17 @@ Empty Response
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-messages-{message_hash}--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3b3b57b3/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-messages-{message_hash}--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -534,18 +527,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-messages-{message_hash}-signatures--post.ts
+```
+            
 ```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3b3b57b3/signatures/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
-```js TypeScript
-// from examples/-v1-messages-{message_hash}-signatures--post.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -585,18 +577,17 @@ Empty Response
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-messages--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/messages/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-messages--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -669,18 +660,17 @@ service needs to derive it itself.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-messages--post.ts
+```
+            
 ```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/messages/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-messages--post.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -726,14 +716,13 @@ Empty Response
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/module-transaction/0x3b3b57b3 \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -787,14 +776,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/module-trans
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-transactions/0xa059b4571d8e6cf551eea796f9d86a414083bdc3d5d5be88486589a7b6214be2/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -916,14 +904,13 @@ Unix UTC epoch time (no milliseconds) and dividing by 3600 (natural division, no
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-transactions/0xa059b4571d8e6cf551eea796f9d86a414083bdc3d5d5be88486589a7b6214be2/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -964,14 +951,13 @@ the given Safe transaction hash
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-transactions/0xa059b4571d8e6cf551eea796f9d86a414083bdc3d5d5be88486589a7b6214be2/confirmations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1026,14 +1012,13 @@ does not support the use of delegates to make transactions trusted.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-transactions/0xa059b4571d8e6cf551eea796f9d86a414083bdc3d5d5be88486589a7b6214be2/confirmations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1089,18 +1074,17 @@ but there will be 2 transactions in the list.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-all-transactions--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/all-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-all-transactions--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1212,14 +1196,13 @@ Only 1000 newest transfers will be returned.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/incoming-transfers/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1278,18 +1261,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-module-transactions--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/module-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-module-transactions--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1351,18 +1333,17 @@ By default, only ``trusted`` multisig transactions are returned.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-multisig-transactions--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/multisig-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-multisig-transactions--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1459,18 +1440,17 @@ retrieves all the information related.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-multisig-transactions--post.ts
+```
+            
 ```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/multisig-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-multisig-transactions--post.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1512,14 +1492,13 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/multisig-transactions/estimations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1562,14 +1541,13 @@ Only 1000 newest transfers will be returned.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/transfers/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1628,14 +1606,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/transfer/3b3b57b3 \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1693,18 +1670,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/transfer/3b3
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-modules-{address}-safes--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/modules/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safes/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-modules-{address}-safes--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1752,18 +1728,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/modules/0xcd
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-owners-{address}-safes--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/owners/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safes/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-owners-{address}-safes--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1821,14 +1796,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/owners/0xcd2
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operations/0x597ba36c626a32a4fcc9f23a4b25605ee30b46584918d6b6442387161dc3c51b/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1902,14 +1876,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operati
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operations/0x597ba36c626a32a4fcc9f23a4b25605ee30b46584918d6b6442387161dc3c51b/confirmations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -1963,14 +1936,13 @@ the use of delegates to make a transaction trusted.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operations/0x597ba36c626a32a4fcc9f23a4b25605ee30b46584918d6b6442387161dc3c51b/confirmations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2010,14 +1982,13 @@ Empty Response
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safe-operations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2098,14 +2069,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safe-operations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
     -d '{}' 
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2145,14 +2115,13 @@ Empty Response
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/user-operations/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2233,18 +2202,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-user-operations-{user_operation_hash}--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/user-operations/0xe6dac94a3cdbab8d807dfbe79ec378713403ff60cb1a1fff09696813d2705b8e/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-user-operations-{user_operation_hash}--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2324,18 +2292,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/user-operati
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2392,14 +2359,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/balances/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2461,18 +2427,17 @@ deployment.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-safes-{address}-creation--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/creation/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-safes-{address}-creation--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2569,14 +2534,13 @@ The maximum limit allowed is 200.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/balances/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2635,14 +2599,13 @@ The maximum limit allowed is 10.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/collectibles/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2706,18 +2669,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-tokens--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-tokens--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2773,18 +2735,17 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/ \
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
+```js TypeScript
+// from examples/-v1-tokens-{address}--get.ts
+```
+            
 ```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
-```js TypeScript
-// from examples/-v1-tokens-{address}--get.ts
-```
-            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2832,14 +2793,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/0xcd2
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/lists/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
@@ -2880,14 +2840,13 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/lists
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
+
 ```bash 
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/analytics/multisig-transactions/by-origin/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
      
 ```
-
-        
       </CH.Code>
     </CH.Section>
     <NetworkNotice />

--- a/components/ApiReference/generated-reference.mdx
+++ b/components/ApiReference/generated-reference.mdx
@@ -58,7 +58,42 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/contracts/ \
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 16233,
+  "next": "https://safe-transaction-sepolia.safe.global/api/v1/contracts/?limit=2&offset=3",
+  "previous": null,
+  "results": [
+    {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "MetaMultiSigWallet",
+      "displayName": "",
+      "logoUri": null,
+      "contractAbi": {
+        "abi": [],
+        "description": "MetaMultiSigWallet",
+        "relevance": 100
+      },
+      "trustedForDelegateCall": false
+    },
+    {
+      "address": "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC",
+      "name": "Seaport",
+      "displayName": "",
+      "logoUri": null,
+      "contractAbi": {
+        "abi": [],
+        "description": "Seaport",
+        "relevance": 100
+      },
+      "trustedForDelegateCall": false
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -100,7 +135,23 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/contracts/0x
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "address": "0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC",
+  "name": "Seaport",
+  "displayName": "",
+  "logoUri": null,
+  "contractAbi": {
+    "abi": [],
+    "description": "Seaport",
+    "relevance": 100
+  },
+  "trustedForDelegateCall": false
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -139,7 +190,7 @@ as in case of an ABI collision the Safe Transaction Service would know which ABI
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/data-decoder/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -147,11 +198,34 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/data-decode
 ```
 
         
+```js TypeScript
+// from examples/-v1-data-decoder--post.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "method": "transfer",
+  "parameters": [
+    {
+      "name": "to",
+      "type": "address",
+      "value": "0x5298A93734C3D979eF1f23F78eBB871879A21F22"
+    },
+    {
+      "name": "value",
+      "type": "uint256",
+      "value": "10000000000000000000"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -187,7 +261,7 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/data-decode
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -195,11 +269,32 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ \
 ```
 
         
+```js TypeScript
+// from examples/-v2-delegates--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "delegate": "0xe8A11B18DA0C02ce6304347D8E0DA66C50dEf739",
+      "delegator": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "label": "Sample Delegator 2"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -260,7 +355,7 @@ Unix UTC epoch time (no milliseconds) and dividing by 3600 (natural division, no
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -268,11 +363,20 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/ 
 ```
 
         
+```js TypeScript
+// from examples/-v2-delegates--post.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -304,7 +408,7 @@ either the `delegator` (owner) or the `delegate` itself. Check `POST /delegates/
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v2/delegates/0xe8A11B18DA0C02ce6304347D8E0DA66C50dEf739/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -312,11 +416,20 @@ curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v2/delegates
 ```
 
         
+```js TypeScript
+// from examples/-v2-delegates-{delegate_address}--delete.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -352,7 +465,7 @@ curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v2/delegates
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3b3b57b3/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -360,11 +473,38 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3
 ```
 
         
+```js TypeScript
+// from examples/-v1-messages-{message_hash}--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "created": "2024-07-29T16:59:00.807652Z",
+  "modified": "2024-07-29T16:59:00.807652Z",
+  "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+  "messageHash": "0x950cfe6090e742b709ab5f662c10c8b4e06d403a2f8c4654d86af45d93fa3777",
+  "message": "string message",
+  "proposedBy": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+  "safeAppId": null,
+  "confirmations": [
+    {
+      "created": "2024-07-29T16:59:00.843249Z",
+      "modified": "2024-07-29T16:59:00.843249Z",
+      "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "signature": "0x5f12f647a876c1966cfbb785d78add0e504cdd0b56b9e21ac93a566d883f80af0192226678ffbe04b35efd23265f1b516a0b0920c679b13d9a5290af0c4b87931f",
+      "signatureType": "ETH_SIGN"
+    }
+  ],
+  "preparedSignature": "0x5f12f647a876c1966cfbb785d78add0e504cdd0b56b9e21ac93a566d883f80af0192226678ffbe04b35efd23265f1b516a0b0920c679b13d9a5290af0c4b87931f"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -394,7 +534,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x3b3b57b3/signatures/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -402,11 +542,20 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x
 ```
 
         
+```js TypeScript
+// from examples/-v1-messages-{message_hash}-signatures--post.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -436,7 +585,7 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/messages/0x
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/messages/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -444,11 +593,45 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-messages--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "created": "2024-07-29T16:59:00.807652Z",
+      "modified": "2024-07-29T16:59:00.807652Z",
+      "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "messageHash": "0x950cfe6090e742b709ab5f662c10c8b4e06d403a2f8c4654d86af45d93fa3777",
+      "message": "string message",
+      "proposedBy": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "safeAppId": null,
+      "confirmations": [
+        {
+          "created": "2024-07-29T16:59:00.843249Z",
+          "modified": "2024-07-29T16:59:00.843249Z",
+          "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+          "signature": "0x5f12f647a876c1966cfbb785d78add0e504cdd0b56b9e21ac93a566d883f80af0192226678ffbe04b35efd23265f1b516a0b0920c679b13d9a5290af0c4b87931f",
+          "signatureType": "ETH_SIGN"
+        }
+      ],
+      "preparedSignature": "0x5f12f647a876c1966cfbb785d78add0e504cdd0b56b9e21ac93a566d883f80af0192226678ffbe04b35efd23265f1b516a0b0920c679b13d9a5290af0c4b87931f"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -486,7 +669,7 @@ service needs to derive it itself.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/messages/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -494,11 +677,20 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-messages--post.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -546,7 +738,26 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/module-trans
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "created": "2024-07-24T20:54:48Z",
+  "executionDate": "2024-07-24T20:54:48Z",
+  "blockNumber": 6369595,
+  "isSuccessful": true,
+  "transactionHash": "0x4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e",
+  "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+  "module": "0x9085149079b87E32178669097bc82D341CB65678",
+  "to": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+  "value": "10000000000",
+  "data": "0x00",
+  "operation": 0,
+  "dataDecoded": null,
+  "moduleTransactionId": "i4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e0,0"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -588,7 +799,60 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-tra
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+  "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "value": "50000000000000",
+  "data": null,
+  "operation": 0,
+  "gasToken": "0x0000000000000000000000000000000000000000",
+  "safeTxGas": 0,
+  "baseGas": 0,
+  "gasPrice": "0",
+  "refundReceiver": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+  "nonce": 0,
+  "executionDate": null,
+  "submissionDate": "2024-06-26T14:57:15.429517Z",
+  "modified": "2024-06-28T14:18:04.121072Z",
+  "blockNumber": null,
+  "transactionHash": null,
+  "safeTxHash": "0x897cab0528ffa8cbe10ee533e636d1a42b9e8d42f8dccb9af9006804d02d2027",
+  "proposer": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+  "executor": null,
+  "isExecuted": false,
+  "isSuccessful": null,
+  "ethGasPrice": null,
+  "maxFeePerGas": null,
+  "maxPriorityFeePerGas": null,
+  "gasUsed": null,
+  "fee": null,
+  "origin": "{}",
+  "dataDecoded": null,
+  "confirmationsRequired": 2,
+  "confirmations": [
+    {
+      "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "submissionDate": "2024-06-26T14:57:15.504003Z",
+      "transactionHash": null,
+      "signature": "0xec2c1cf656d997f92247ddf59f30ce718de990ec4f8d4670a37d3d3594862f0d49ad2c553daa2ff937c50d45e9ca6a815f826d29603f8c5c818cb698ddc2383a20",
+      "signatureType": "ETH_SIGN"
+    },
+    {
+      "owner": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+      "submissionDate": "2024-06-28T14:18:04.121072Z",
+      "transactionHash": null,
+      "signature": "0xfc32b5fdfa8517b44bd45c5d1e09ed898325e109e6b889fbf1584c158dcbe71b2de4a1e8d43b5d396c1da03381cbc3f8358295192d19ded2c12dda90227308b720",
+      "signatureType": "ETH_SIGN"
+    }
+  ],
+  "trusted": true,
+  "signatures": null
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -664,7 +928,12 @@ curl -X DELETE https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -707,7 +976,25 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-tra
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "submissionDate": "2024-06-26T14:57:15.504003Z",
+      "transactionHash": null,
+      "signature": "0xec2c1cf656d997f92247ddf59f30ce718de990ec4f8d4670a37d3d3594862f0d49ad2c553daa2ff937c50d45e9ca6a815f826d29603f8c5c818cb698ddc2383a20",
+      "signatureType": "ETH_SIGN"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -751,7 +1038,14 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/multisig-tr
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "signature": "0xfc32b5fdfa8517b44bd45c5d1e09ed898325e109e6b889fbf1584c158dcbe71b2de4a1e8d43b5d396c1da03381cbc3f8358295192d19ded2c12dda90227308b720"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -795,7 +1089,7 @@ but there will be 2 transactions in the list.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/all-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -803,11 +1097,91 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-all-transactions--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "value": "50000000000000",
+      "data": null,
+      "operation": 0,
+      "gasToken": "0x0000000000000000000000000000000000000000",
+      "safeTxGas": 0,
+      "baseGas": 0,
+      "gasPrice": "0",
+      "refundReceiver": "0x0000000000000000000000000000000000000000",
+      "nonce": 0,
+      "executionDate": "2024-06-26T15:41:48Z",
+      "submissionDate": "2024-06-26T15:18:33.817634Z",
+      "modified": "2024-06-26T15:41:49.400858Z",
+      "blockNumber": 6191662,
+      "transactionHash": "0x2ecba24115d057bb74c1885b2a16a38b3929992fd52ed69dc8d0df24f765da96",
+      "safeTxHash": "0xfc01da65f3a1dea769f4ad9067d41c5477a2ec5316d6b54165de212cd1681992",
+      "proposer": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "executor": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "isExecuted": true,
+      "isSuccessful": true,
+      "ethGasPrice": "61733665357",
+      "maxFeePerGas": "131260008170",
+      "maxPriorityFeePerGas": "1000000000",
+      "gasUsed": 91398,
+      "fee": "5642333546299086",
+      "origin": "{}",
+      "dataDecoded": null,
+      "confirmationsRequired": 2,
+      "confirmations": [
+        {
+          "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+          "submissionDate": "2024-06-26T15:18:33.901378Z",
+          "transactionHash": null,
+          "signature": "0x331d8584f5514c1cf1cfe1edd873228e428dafc0c78c5480c34c9868e9075d9622d8334d052037b1566241c8d0ecfbdb02c99b59a9e06d97974e1eaa55f502811f",
+          "signatureType": "ETH_SIGN"
+        },
+        {
+          "owner": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+          "submissionDate": "2024-06-26T15:27:29.512252Z",
+          "transactionHash": null,
+          "signature": "0xd26842f2bd17eeed83a0f9fb010efc1716ed982e62cc05fe61a314827c226d534ddab07482795521b20c32d764ddc4d3fc602c3113b4c540c420e72b923b92c91f",
+          "signatureType": "ETH_SIGN"
+        }
+      ],
+      "trusted": true,
+      "signatures": "0xd26842f2bd17eeed83a0f9fb010efc1716ed982e62cc05fe61a314827c226d534ddab07482795521b20c32d764ddc4d3fc602c3113b4c540c420e72b923b92c91f331d8584f5514c1cf1cfe1edd873228e428dafc0c78c5480c34c9868e9075d9622d8334d052037b1566241c8d0ecfbdb02c99b59a9e06d97974e1eaa55f502811f",
+      "transfers": [
+        {
+          "type": "ETHER_TRANSFER",
+          "executionDate": "2024-06-26T15:41:48Z",
+          "blockNumber": 6191662,
+          "transactionHash": "0x2ecba24115d057bb74c1885b2a16a38b3929992fd52ed69dc8d0df24f765da96",
+          "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "value": "50000000000000",
+          "tokenId": null,
+          "tokenAddress": null,
+          "transferId": "i2ecba24115d057bb74c1885b2a16a38b3929992fd52ed69dc8d0df24f765da960,0",
+          "tokenInfo": null,
+          "from": "0x5298A93734C3D979eF1f23F78eBB871879A21F22"
+        }
+      ],
+      "txType": "MULTISIG_TRANSACTION"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -850,7 +1224,31 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "type": "ETHER_TRANSFER",
+      "executionDate": "2024-06-25T11:19:00Z",
+      "blockNumber": 6183150,
+      "transactionHash": "0x28fd99978fe7a05160f8da40311cb2e796f17d23f7a3eaea243d4a7f2f636924",
+      "to": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "value": "10000000000000000",
+      "tokenId": null,
+      "tokenAddress": null,
+      "transferId": "i28fd99978fe7a05160f8da40311cb2e796f17d23f7a3eaea243d4a7f2f636924",
+      "tokenInfo": null,
+      "from": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -880,7 +1278,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/module-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -888,11 +1286,41 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-module-transactions--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "created": "2024-07-24T20:54:48Z",
+      "executionDate": "2024-07-24T20:54:48Z",
+      "blockNumber": 6369595,
+      "isSuccessful": true,
+      "transactionHash": "0x4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e",
+      "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "module": "0x9085149079b87E32178669097bc82D341CB65678",
+      "to": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+      "value": "10000000000",
+      "data": "0x00",
+      "operation": 0,
+      "dataDecoded": null,
+      "moduleTransactionId": "i4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e0,0"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -923,7 +1351,7 @@ By default, only ``trusted`` multisig transactions are returned.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/multisig-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -931,11 +1359,76 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-multisig-transactions--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "safe": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+      "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "value": "50000000000000",
+      "data": null,
+      "operation": 0,
+      "gasToken": "0x0000000000000000000000000000000000000000",
+      "safeTxGas": 0,
+      "baseGas": 0,
+      "gasPrice": "0",
+      "refundReceiver": "0x0000000000000000000000000000000000000000",
+      "nonce": 0,
+      "executionDate": "2024-06-26T15:41:48Z",
+      "submissionDate": "2024-06-26T15:18:33.817634Z",
+      "modified": "2024-06-26T15:41:49.400858Z",
+      "blockNumber": 6191662,
+      "transactionHash": "0x2ecba24115d057bb74c1885b2a16a38b3929992fd52ed69dc8d0df24f765da96",
+      "safeTxHash": "0xfc01da65f3a1dea769f4ad9067d41c5477a2ec5316d6b54165de212cd1681992",
+      "proposer": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "executor": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+      "isExecuted": true,
+      "isSuccessful": true,
+      "ethGasPrice": "61733665357",
+      "maxFeePerGas": "131260008170",
+      "maxPriorityFeePerGas": "1000000000",
+      "gasUsed": 91398,
+      "fee": "5642333546299086",
+      "origin": "{}",
+      "dataDecoded": null,
+      "confirmationsRequired": 2,
+      "confirmations": [
+        {
+          "owner": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+          "submissionDate": "2024-06-26T15:18:33.901378Z",
+          "transactionHash": null,
+          "signature": "0x331d8584f5514c1cf1cfe1edd873228e428dafc0c78c5480c34c9868e9075d9622d8334d052037b1566241c8d0ecfbdb02c99b59a9e06d97974e1eaa55f502811f",
+          "signatureType": "ETH_SIGN"
+        },
+        {
+          "owner": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+          "submissionDate": "2024-06-26T15:27:29.512252Z",
+          "transactionHash": null,
+          "signature": "0xd26842f2bd17eeed83a0f9fb010efc1716ed982e62cc05fe61a314827c226d534ddab07482795521b20c32d764ddc4d3fc602c3113b4c540c420e72b923b92c91f",
+          "signatureType": "ETH_SIGN"
+        }
+      ],
+      "trusted": true,
+      "signatures": "0xd26842f2bd17eeed83a0f9fb010efc1716ed982e62cc05fe61a314827c226d534ddab07482795521b20c32d764ddc4d3fc602c3113b4c540c420e72b923b92c91f331d8584f5514c1cf1cfe1edd873228e428dafc0c78c5480c34c9868e9075d9622d8334d052037b1566241c8d0ecfbdb02c99b59a9e06d97974e1eaa55f502811f"
+    }
+  ],
+  "countUniqueNonce": 1
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -966,7 +1459,7 @@ retrieves all the information related.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/multisig-transactions/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -974,11 +1467,22 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-multisig-transactions--post.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "safeTxGas": "45683"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1020,7 +1524,14 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "safeTxGas": "42806"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1063,7 +1574,31 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "type": "ETHER_TRANSFER",
+      "executionDate": "2024-07-24T20:54:48Z",
+      "blockNumber": 6369595,
+      "transactionHash": "0x4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e",
+      "to": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+      "value": "10000000000",
+      "tokenId": null,
+      "tokenAddress": null,
+      "transferId": "i4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e0,0,0",
+      "tokenInfo": null,
+      "from": "0x5298A93734C3D979eF1f23F78eBB871879A21F22"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1105,7 +1640,24 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/transfer/3b3
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "type": "ETHER_TRANSFER",
+  "executionDate": "2024-07-24T20:54:48Z",
+  "blockNumber": 6369595,
+  "transactionHash": "0x4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e",
+  "to": "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d",
+  "value": "10000000000",
+  "tokenId": null,
+  "tokenAddress": null,
+  "transferId": "i4c8bc3a9f32eed6b4cb8225d6884e9c7006d6740b0a6896cee7b254aa037920e0,0,0",
+  "tokenInfo": null,
+  "from": "0x5298A93734C3D979eF1f23F78eBB871879A21F22"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1141,7 +1693,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/transfer/3b3
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/modules/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safes/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1149,11 +1701,22 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/modules/0xcd
 ```
 
         
+```js TypeScript
+// from examples/-v1-modules-{address}-safes--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "safes": ["0x5298A93734C3D979eF1f23F78eBB871879A21F22"]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1189,7 +1752,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/modules/0xcd
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/owners/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/safes/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1197,11 +1760,32 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/owners/0xcd2
 ```
 
         
+```js TypeScript
+// from examples/-v1-owners-{address}-safes--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "safes": [
+    "0xd0540ECBB3010E5f8d780B62Af3aB936fB6C0c75",
+    "0x44eBdc9aCE42d6742a3df2813CB437834e6F05B0",
+    "0x25D641a9eE275CE94b64bE1227e610b77e776522",
+    "0xeFEe5E6394a02eE0ba61731Da014eE8aE8BcDe83",
+    "0xCfF743C4445eAd58105a793B34eB02125e830dB0",
+    "0x27000f745b020bD386D7712A4ca32AF7a2E3A7Fe",
+    "0xb53a6B6f67847cfF94fDb94B90345cB45a2c7301",
+    "0x1f01FC62f168099493705bDF7A05b539946832bc",
+    "0x5298A93734C3D979eF1f23F78eBB871879A21F22"
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1249,7 +1833,46 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operati
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "created": "2024-07-22T10:00:18.892702Z",
+  "modified": "2024-07-22T10:00:18.892702Z",
+  "safeOperationHash": "0xb59828b1d3b0363641e3bb4d72dd63565d1062a40c6d05469caa0218ce8e0445",
+  "validAfter": null,
+  "validUntil": null,
+  "moduleAddress": "0xa581c4A4DB7175302464fF3C06380BC3270b4037",
+  "confirmations": [
+    {
+      "created": "2024-07-22T10:00:18.898708Z",
+      "modified": "2024-07-22T10:00:18.898708Z",
+      "owner": "0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1",
+      "signature": "0x000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+      "signatureType": "CONTRACT_SIGNATURE"
+    }
+  ],
+  "preparedSignature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+  "userOperation": {
+    "ethereumTxHash": "0xfe7bc7fcab04ad689e1c5fcca7ad5345481fddc462880655a9a39b827da7b4ac",
+    "sender": "0x125eb8CcAC85EA322C3859648509823CA05aD7e5",
+    "userOperationHash": "0x3545a04aa1d10b74164af413253ab0881c86ebe219e166207b3175923202bbc7",
+    "nonce": 0,
+    "initCode": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec671688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe91900c7620000000000000000000000000000000000000000000000000000000000000060ad27de2a410652abce96ea0fdfc30c2f0fd35952b78f554667111999a28ff3380000000000000000000000000000000000000000000000000000000000000344b63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000038869bf66a61cf6bdb996a6ae40d5853fd43b5260000000000000000000000000000000000000000000000000000000000000140000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b40370000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f100000000000000000000000000000000000000000000000000000000000001c48d80ff0a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000172018ecd4ec46d4d2a6b64fe960b3d64e8b94b2234eb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000648d0dc49f00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b403701608cf2e3412c6bda14e6d8a0a7d27c4240fed6f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000640dd9692f4255f6101637c8b43bf63660ffba39cab522b053094b2a07535d7d848ce5efca9aae34aabaee7600328bb0fb5f6a6c5214c8db9303f824f52f2fca42f2b342ce000000000000000000000000ca89cba4813d5b40aec6e57a30d0eeb500d6531b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "callData": "0x7bb3742800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "callGasLimit": 198268,
+    "verificationGasLimit": 3867576,
+    "preVerificationGas": 110646,
+    "maxFeePerGas": 36776375378,
+    "maxPriorityFeePerGas": 199436407,
+    "paymaster": "0xDFF7FA1077Bce740a6a212b3995990682c0Ba66d",
+    "paymasterData": "0x00000000000000000000000000000000000000000000000000000000669e2fe1000000000000000000000000000000000000000000000000000000000000000037a31ba85cc6a4753d5fb73e475ddf22c9ab9a9ce405fdff217c03bff161bc893e7658160bd3cabaefad55b2d5751713484b8b90ef54d85e356916b4fede3dc11b",
+    "signature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+    "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+  }
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1291,7 +1914,25 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operati
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "created": "2024-07-22T10:00:18.898708Z",
+      "modified": "2024-07-22T10:00:18.898708Z",
+      "owner": "0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1",
+      "signature": "0x000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+      "signatureType": "CONTRACT_SIGNATURE"
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1334,7 +1975,12 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safe-operat
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1376,7 +2022,53 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "created": "2024-07-22T10:00:18.892702Z",
+      "modified": "2024-07-22T10:00:18.892702Z",
+      "safeOperationHash": "0xb59828b1d3b0363641e3bb4d72dd63565d1062a40c6d05469caa0218ce8e0445",
+      "validAfter": null,
+      "validUntil": null,
+      "moduleAddress": "0xa581c4A4DB7175302464fF3C06380BC3270b4037",
+      "confirmations": [
+        {
+          "created": "2024-07-22T10:00:18.898708Z",
+          "modified": "2024-07-22T10:00:18.898708Z",
+          "owner": "0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1",
+          "signature": "0x000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+          "signatureType": "CONTRACT_SIGNATURE"
+        }
+      ],
+      "preparedSignature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+      "userOperation": {
+        "ethereumTxHash": "0xfe7bc7fcab04ad689e1c5fcca7ad5345481fddc462880655a9a39b827da7b4ac",
+        "sender": "0x125eb8CcAC85EA322C3859648509823CA05aD7e5",
+        "userOperationHash": "0x3545a04aa1d10b74164af413253ab0881c86ebe219e166207b3175923202bbc7",
+        "nonce": 0,
+        "initCode": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec671688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe91900c7620000000000000000000000000000000000000000000000000000000000000060ad27de2a410652abce96ea0fdfc30c2f0fd35952b78f554667111999a28ff3380000000000000000000000000000000000000000000000000000000000000344b63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000038869bf66a61cf6bdb996a6ae40d5853fd43b5260000000000000000000000000000000000000000000000000000000000000140000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b40370000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f100000000000000000000000000000000000000000000000000000000000001c48d80ff0a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000172018ecd4ec46d4d2a6b64fe960b3d64e8b94b2234eb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000648d0dc49f00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b403701608cf2e3412c6bda14e6d8a0a7d27c4240fed6f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000640dd9692f4255f6101637c8b43bf63660ffba39cab522b053094b2a07535d7d848ce5efca9aae34aabaee7600328bb0fb5f6a6c5214c8db9303f824f52f2fca42f2b342ce000000000000000000000000ca89cba4813d5b40aec6e57a30d0eeb500d6531b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "callData": "0x7bb3742800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "callGasLimit": 198268,
+        "verificationGasLimit": 3867576,
+        "preVerificationGas": 110646,
+        "maxFeePerGas": 36776375378,
+        "maxPriorityFeePerGas": 199436407,
+        "paymaster": "0xDFF7FA1077Bce740a6a212b3995990682c0Ba66d",
+        "paymasterData": "0x00000000000000000000000000000000000000000000000000000000669e2fe1000000000000000000000000000000000000000000000000000000000000000037a31ba85cc6a4753d5fb73e475ddf22c9ab9a9ce405fdff217c03bff161bc893e7658160bd3cabaefad55b2d5751713484b8b90ef54d85e356916b4fede3dc11b",
+        "signature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+        "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+      }
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1418,7 +2110,12 @@ curl -X POST https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+Empty Response
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1460,7 +2157,53 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "ethereumTxHash": "0xfe7bc7fcab04ad689e1c5fcca7ad5345481fddc462880655a9a39b827da7b4ac",
+      "sender": "0x125eb8CcAC85EA322C3859648509823CA05aD7e5",
+      "userOperationHash": "0x3545a04aa1d10b74164af413253ab0881c86ebe219e166207b3175923202bbc7",
+      "nonce": 0,
+      "initCode": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec671688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe91900c7620000000000000000000000000000000000000000000000000000000000000060ad27de2a410652abce96ea0fdfc30c2f0fd35952b78f554667111999a28ff3380000000000000000000000000000000000000000000000000000000000000344b63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000038869bf66a61cf6bdb996a6ae40d5853fd43b5260000000000000000000000000000000000000000000000000000000000000140000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b40370000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f100000000000000000000000000000000000000000000000000000000000001c48d80ff0a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000172018ecd4ec46d4d2a6b64fe960b3d64e8b94b2234eb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000648d0dc49f00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b403701608cf2e3412c6bda14e6d8a0a7d27c4240fed6f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000640dd9692f4255f6101637c8b43bf63660ffba39cab522b053094b2a07535d7d848ce5efca9aae34aabaee7600328bb0fb5f6a6c5214c8db9303f824f52f2fca42f2b342ce000000000000000000000000ca89cba4813d5b40aec6e57a30d0eeb500d6531b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "callData": "0x7bb3742800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "callGasLimit": 198268,
+      "verificationGasLimit": 3867576,
+      "preVerificationGas": 110646,
+      "maxFeePerGas": 36776375378,
+      "maxPriorityFeePerGas": 199436407,
+      "paymaster": "0xDFF7FA1077Bce740a6a212b3995990682c0Ba66d",
+      "paymasterData": "0x00000000000000000000000000000000000000000000000000000000669e2fe1000000000000000000000000000000000000000000000000000000000000000037a31ba85cc6a4753d5fb73e475ddf22c9ab9a9ce405fdff217c03bff161bc893e7658160bd3cabaefad55b2d5751713484b8b90ef54d85e356916b4fede3dc11b",
+      "signature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+      "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+      "safeOperation": {
+        "created": "2024-07-22T10:00:18.892702Z",
+        "modified": "2024-07-22T10:00:18.892702Z",
+        "safeOperationHash": "0xb59828b1d3b0363641e3bb4d72dd63565d1062a40c6d05469caa0218ce8e0445",
+        "validAfter": null,
+        "validUntil": null,
+        "moduleAddress": "0xa581c4A4DB7175302464fF3C06380BC3270b4037",
+        "confirmations": [
+          {
+            "created": "2024-07-22T10:00:18.898708Z",
+            "modified": "2024-07-22T10:00:18.898708Z",
+            "owner": "0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1",
+            "signature": "0x000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+            "signatureType": "CONTRACT_SIGNATURE"
+          }
+        ],
+        "preparedSignature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f"
+      }
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1490,7 +2233,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/user-operations/0xe6dac94a3cdbab8d807dfbe79ec378713403ff60cb1a1fff09696813d2705b8e/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1498,11 +2241,54 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/user-operati
 ```
 
         
+```js TypeScript
+// from examples/-v1-user-operations-{user_operation_hash}--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "ethereumTxHash": "0xfe7bc7fcab04ad689e1c5fcca7ad5345481fddc462880655a9a39b827da7b4ac",
+  "sender": "0x125eb8CcAC85EA322C3859648509823CA05aD7e5",
+  "userOperationHash": "0x3545a04aa1d10b74164af413253ab0881c86ebe219e166207b3175923202bbc7",
+  "nonce": 0,
+  "initCode": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec671688f0b900000000000000000000000029fcb43b46531bca003ddc8fcb67ffe91900c7620000000000000000000000000000000000000000000000000000000000000060ad27de2a410652abce96ea0fdfc30c2f0fd35952b78f554667111999a28ff3380000000000000000000000000000000000000000000000000000000000000344b63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000038869bf66a61cf6bdb996a6ae40d5853fd43b5260000000000000000000000000000000000000000000000000000000000000140000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b40370000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f100000000000000000000000000000000000000000000000000000000000001c48d80ff0a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000172018ecd4ec46d4d2a6b64fe960b3d64e8b94b2234eb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000648d0dc49f00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a581c4a4db7175302464ff3c06380bc3270b403701608cf2e3412c6bda14e6d8a0a7d27c4240fed6f1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000640dd9692f4255f6101637c8b43bf63660ffba39cab522b053094b2a07535d7d848ce5efca9aae34aabaee7600328bb0fb5f6a6c5214c8db9303f824f52f2fca42f2b342ce000000000000000000000000ca89cba4813d5b40aec6e57a30d0eeb500d6531b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "callData": "0x7bb3742800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "callGasLimit": 198268,
+  "verificationGasLimit": 3867576,
+  "preVerificationGas": 110646,
+  "maxFeePerGas": 36776375378,
+  "maxPriorityFeePerGas": 199436407,
+  "paymaster": "0xDFF7FA1077Bce740a6a212b3995990682c0Ba66d",
+  "paymasterData": "0x00000000000000000000000000000000000000000000000000000000669e2fe1000000000000000000000000000000000000000000000000000000000000000037a31ba85cc6a4753d5fb73e475ddf22c9ab9a9ce405fdff217c03bff161bc893e7658160bd3cabaefad55b2d5751713484b8b90ef54d85e356916b4fede3dc11b",
+  "signature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+  "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+  "safeOperation": {
+    "created": "2024-07-22T10:00:18.892702Z",
+    "modified": "2024-07-22T10:00:18.892702Z",
+    "safeOperationHash": "0xb59828b1d3b0363641e3bb4d72dd63565d1062a40c6d05469caa0218ce8e0445",
+    "validAfter": null,
+    "validUntil": null,
+    "moduleAddress": "0xa581c4A4DB7175302464fF3C06380BC3270b4037",
+    "confirmations": [
+      {
+        "created": "2024-07-22T10:00:18.898708Z",
+        "modified": "2024-07-22T10:00:18.898708Z",
+        "owner": "0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1",
+        "signature": "0x000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f",
+        "signatureType": "CONTRACT_SIGNATURE"
+      }
+    ],
+    "preparedSignature": "0x000000000000000000000000000000000000000000000000608cf2e3412c6bda14e6d8a0a7d27c4240fed6f10000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e053c4ce48756bae15e3454ad75ee8d4ba9764ea37ed561b216701c3630c0521774f94a8b7351780daa4a241792f52089af776e0898185318053201a92865b08d0000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303030222c2263726f73734f726967696e223a66616c736500000000000000000000001f"
+  }
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1538,7 +2324,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/user-operati
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1546,11 +2332,37 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "address": "0x5298A93734C3D979eF1f23F78eBB871879A21F22",
+  "nonce": 6,
+  "threshold": 2,
+  "owners": [
+    "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+    "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d"
+  ],
+  "masterCopy": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+  "modules": [
+    "0x9085149079b87E32178669097bc82D341CB65678",
+    "0xFBbFe0716F25045975f193cccBDbE2a995840657",
+    "0xB4F5e59987549a2586976e8957962dBD54a26FD0"
+  ],
+  "fallbackHandler": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+  "guard": "0x0000000000000000000000000000000000000000",
+  "version": "1.3.0+L2"
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1592,7 +2404,30 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+[
+  // Native coin (Sepolia ETH):
+  {
+    "tokenAddress": null,
+    "token": null,
+    "balance": "9899990000000000"
+  },
+  // ERC20 token:
+  {
+    "tokenAddress": "0x0D5b70467E61125b242E70831aEd15D7C12E3F0D",
+    "token": {
+      "name": "SampleToken",
+      "symbol": "ST",
+      "decimals": 18,
+      "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0x0D5b70467E61125b242E70831aEd15D7C12E3F0D.png"
+    },
+    "balance": "10000000000000000000"
+  }
+]
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1626,7 +2461,7 @@ deployment.
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/creation/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1634,11 +2469,76 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/safes/0xcd2E
 ```
 
         
+```js TypeScript
+// from examples/-v1-safes-{address}-creation--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "created": "2024-06-25T11:18:48Z",
+  "creator": "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+  "transactionHash": "0x6404e0298423c092cc1ce486f3f72172a1c0f2f28a9b29f69e605ea825360ac5",
+  "factoryAddress": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+  "masterCopy": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+  "setupData": "0xb63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000160000000000000000000000000017062a1de2fe6b99be3d9d37841fed19f5738040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a6d3debaab2b8093e69109f23a75501f864f74e20000000000000000000000003a16e3090e32dded2250e862b9d5610bef13e93d0000000000000000000000000000000000000000000000000000000000000000",
+  "dataDecoded": {
+    "method": "setup",
+    "parameters": [
+      {
+        "name": "_owners",
+        "type": "address[]",
+        "value": [
+          "0xa6d3DEBAAB2B8093e69109f23A75501F864F74e2",
+          "0x3A16E3090e32DDeD2250E862B9d5610BEF13e93d"
+        ]
+      },
+      {
+        "name": "_threshold",
+        "type": "uint256",
+        "value": "2"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "value": "0x"
+      },
+      {
+        "name": "fallbackHandler",
+        "type": "address",
+        "value": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "name": "payment",
+        "type": "uint256",
+        "value": "0"
+      },
+      {
+        "name": "paymentReceiver",
+        "type": "address",
+        "value": "0x0000000000000000000000000000000000000000"
+      }
+    ]
+  },
+  "userOperation": null
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1681,7 +2581,30 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+[
+  // Native coin (Sepolia ETH):
+  {
+    "tokenAddress": null,
+    "token": null,
+    "balance": "9899990000000000"
+  },
+  // ERC20 token:
+  {
+    "tokenAddress": "0x0D5b70467E61125b242E70831aEd15D7C12E3F0D",
+    "token": {
+      "name": "SampleToken",
+      "symbol": "ST",
+      "decimals": 18,
+      "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0x0D5b70467E61125b242E70831aEd15D7C12E3F0D.png"
+    },
+    "balance": "10000000000000000000"
+  }
+]
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1724,7 +2647,30 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "address": "0xa0D601bc48Bae6D64bB19d325f8A6618A4da9490",
+      "tokenName": "SampleNft",
+      "tokenSymbol": "SN",
+      "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0xa0D601bc48Bae6D64bB19d325f8A6618A4da9490.png",
+      "id": "1",
+      "uri": null,
+      "name": null,
+      "description": null,
+      "imageUri": null,
+      "metadata": {}
+    }
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1760,7 +2706,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v2/safes/0xcd2E
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1768,11 +2714,36 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/ \
 ```
 
         
+```js TypeScript
+// from examples/-v1-tokens--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "count": 1846,
+  "next": "https://safe-transaction-sepolia.safe.global/api/v1/tokens/?limit=10&offset=10",
+  "previous": null,
+  "results": [
+    {
+      "type": "ERC20",
+      "address": "0x687e43D0aB3248bDfebFE3E8f9F1AB2B9FcE982d",
+      "name": "0x5555.com",
+      "symbol": "0x5555.com",
+      "decimals": 18,
+      "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0x687e43D0aB3248bDfebFE3E8f9F1AB2B9FcE982d.png",
+      "trusted": false
+    }
+    // ...
+  ]
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 
@@ -1802,7 +2773,7 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/ \
 
     <CH.Section>
       <CH.Code style={{boxShadow: 'none'}}>
-```bash 
+```bash curl
 curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/0xcd2E72aEBe2A203b84f46DEEC948E6465dB51c75/ \
     -H "Accept: application/json" \
     -H "content-type: application/json" \
@@ -1810,11 +2781,28 @@ curl -X GET https://safe-transaction-sepolia.safe.global/api/api/v1/tokens/0xcd2
 ```
 
         
+```js TypeScript
+// from examples/-v1-tokens-{address}--get.ts
+```
+            
       </CH.Code>
     </CH.Section>
     <NetworkNotice />
 
-    
+    #### Sample Response
+
+```json
+{
+  "type": "ERC20",
+  "address": "0x687e43D0aB3248bDfebFE3E8f9F1AB2B9FcE982d",
+  "name": "0x5555.com",
+  "symbol": "0x5555.com",
+  "decimals": 18,
+  "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0x687e43D0aB3248bDfebFE3E8f9F1AB2B9FcE982d.png",
+  "trusted": false
+}
+
+```
   </Grid>
 </Grid>
 <Hr style={{ 

--- a/components/ApiReference/mainnet-swagger.json
+++ b/components/ApiReference/mainnet-swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Safe Transaction Service",
-    "version": "5.14.0",
+    "version": "5.15.0",
     "description": "API to keep track of transactions sent via Safe smart contracts"
   },
   "paths": {


### PR DESCRIPTION
This PR fixes four bugs with the API reference after the transaction service upgraded it's Swagger version:
- Query parameters' types were not displayed
- Sample responses were not displayed
- Typescript examples were not displayed
- Response parameters with multiple types were not displayed correctly (e.g. `stringnull` instead of `string | null`)