### PR TITLE
fix: Update createPasskeySigner reference

### DIFF
--- a/pages/reference-sdk-protocol-kit/passkeys/createpasskeysigner.mdx
+++ b/pages/reference-sdk-protocol-kit/passkeys/createpasskeysigner.mdx
@@ -27,7 +27,13 @@ const protocolKit = await Safe.init({
 
 The WebAuthn credential to use for signing.
 
-### Returns
+```typescript focus=2
+const passkeySigner = await Safe.createPasskeySigner(
+  credential
+)
+```
+
+## Returns
 
 `Promise<Pick<PasskeyArgType, 'rawId' | 'coordinates'>>`
 


### PR DESCRIPTION
## Context
This PR:
- Fixes the indentation of the `return` section in the reference.
- Adds the code snippet for the `credential` parameter of the function.