### PR TITLE
Add on-chain tracking version info and form submission link

### DIFF
--- a/pages/sdk/onchain-tracking.mdx
+++ b/pages/sdk/onchain-tracking.mdx
@@ -1,4 +1,4 @@
-import { Tabs, Steps } from 'nextra/components'
+import { Tabs, Steps, Callout } from 'nextra/components'
 
 # On-chain Tracking
 
@@ -7,6 +7,10 @@ We aim to understand better and recognise our key contributors who are driving t
 Implementing a Safe on-chain identifier enables tracking of complex data, such as whether a Safe transaction is executed via our SDK or another, whether it originates from a platform like a Safe App or widget (for example, the CoW Swap widget in our Safe interface), the tool version, the project, and more.
 
 By submitting your on-chain identifier through the form provided at the end of this page, you will help us accurately attribute activity and allow us to return value to our Ecosystem Partners in the future.
+
+<Callout type='info' emoji='ℹ️'>
+  On-chain tracking supported in [Protocol Kit](../sdk/protocol-kit.mdx) `v5.2.0` and [Relay Kit](../sdk/relay-kit.mdx) `v3.4.0` or later.
+</Callout>
 
 ## On-chain identifier format
 
@@ -214,6 +218,8 @@ The on-chain identifier allows tracking the deployment of Safe accounts, the exe
 </Steps>
 
 ## Submission Form
+
+You can fill out the form by clicking [this link](https://forms.gle/NYkorYebc6Fz1fMW6) or using the form below:
 
 <br/>
 


### PR DESCRIPTION
Added information about the minimum required versions for on-chain tracking in Protocol Kit and Relay Kit:

<img width="894" alt="Captura de pantalla 2025-01-20 a las 17 47 58" src="https://github.com/user-attachments/assets/4276c44b-9fff-47e2-9c0c-4659cbf8f987" />

Included a link to the on-chain tracking form, allowing users to fill it out in a new tab or directly within the documentation.

<img width="995" alt="Captura de pantalla 2025-01-20 a las 17 48 03" src="https://github.com/user-attachments/assets/845cdfe5-f6bf-4a30-8015-025d4bc78a1f" />