### PR TITLE
Remove extra lines in property descriptions to avoid `:return:` expressions

### DIFF
--- a/components/ApiReference/Property.tsx
+++ b/components/ApiReference/Property.tsx
@@ -110,7 +110,7 @@ const Property: React.FC<{ property: any; required?: boolean }> = ({
                 }
               }}
             >
-              {property.value?.description?.split('\n')?.[0] ?? ''}
+              {property.value?.description?.split(':param obj:')?.[0] ?? ''}
             </Typography>
           </Grid>
         </Grid>

--- a/components/ApiReference/Property.tsx
+++ b/components/ApiReference/Property.tsx
@@ -110,7 +110,7 @@ const Property: React.FC<{ property: any; required?: boolean }> = ({
                 }
               }}
             >
-              {property.value?.description}
+              {property.value?.description?.split('\n')?.[0] ?? ''}
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
## What it solves

This PR fixes a display error where some properties descriptions include type definitions, due to how they are defined in the transaction-service repo (e.g.: [here](https://github.com/safe-global/safe-transaction-service/blob/dffb7564221bcdf6f66efce2098a8c65fb9a33dc/safe_transaction_service/history/serializers.py#L896)).

## How it solves it

To fix it, we stop displaying the lines after the first keyword (`:param obj:`) in the description, effectively removing the extra type definitions.

## Result

Before: 
<img width="522" alt="Capture d’écran 2025-01-30 à 17 15 17" src="https://github.com/user-attachments/assets/03397712-9dfe-4122-96c5-50f656213c0e" />

After:

<img width="521" alt="Capture d’écran 2025-01-30 à 17 14 03" src="https://github.com/user-attachments/assets/cc479337-64f5-4eb8-adfe-776656a77abc" />

