### PR TITLE
Fix grammatical error in Safe Modules' documentation

### DIFF
--- a/pages/advanced/smart-account-modules.mdx
+++ b/pages/advanced/smart-account-modules.mdx
@@ -21,7 +21,7 @@ Safe Modules can include daily spending allowances, amounts that can be spent wi
 
 ![diagram-safe-modules](../../assets/diagram-safe-modules.png)
 
-## How to Safe Modules Work
+## How Safe Modules Work
 
 1. **Enabling a Module**: A module is added to the Safe via the `enableModule()` function. The Safe maintains an internal registry of authorized modules.
 2. **Transaction Execution**:


### PR DESCRIPTION
This PR fixes a grammatical error in the documentation heading to improve clarity. Corrected 'How _to_ Safe Modules Work' to 'How Safe Modules Work'. 