### PR TITLE
Add a page on multi chain safe deployment

### DIFF
--- a/pages/advanced/_meta.json
+++ b/pages/advanced/_meta.json
@@ -12,6 +12,7 @@
   "smart-account-modules": "Safe Modules",
   "smart-account-guards": "Safe Guards",
   "smart-account-signatures": "Signatures",
+  "smart-account-multi-chain-deployment": "Multi-Chain Deployment",
   "smart-account-supported-networks": {
     "title": "Supported Networks",
     "theme": {

--- a/pages/advanced/smart-account-multi-chain-deployment.mdx
+++ b/pages/advanced/smart-account-multi-chain-deployment.mdx
@@ -1,0 +1,46 @@
+# Deploying Safe Account on Multiple Chains
+
+## Why?
+
+Deploying a Safe account on multiple chains can be useful in scenarios such as:
+
+- **Accidental Fund Transfers**: If funds are accidentally sent to a chain where the Safe does not exist, having the ability to deploy the Safe on that chain can help recover those funds.
+- **Cross-Chain Operations**: For users who operate on multiple chains, having the same Safe address on different chains can simplify operations and management.
+
+## How?
+
+Apart from building transaction with appropriate parameters to deploy a Safe on multiple chains at the same address, it is also possible to use the following methods:
+
+- **Safe Wallet UI**: The Safe Wallet UI allows users to deploy a Safe on multiple chains at the same address.
+- **Safe Protocol Kit**: The Safe Protocol Kit supports deploying a Safe on multiple chains at the same address. For more details, refer to the [Safe Protocol Kit documentation](https://docs.safe.global/sdk/protocol-kit/guides/multichain-safe-deployment).
+
+### Deployment Process
+
+The deployment process happens through a Proxy Factory contract using deterministic deployment (that is, the `create2` opcode). The address of the deployed Safe depends on the following factors:
+
+- The address of the factory
+- The singleton contract
+- The salt
+- The `initializer` data used
+- Proxy `creationcode`
+
+## Exceptions
+
+- **Non-EVM Compatible Chains**: Chains that are not EVM compatible (for example, ZKSyncEra) will not be able to use this method.
+- **Compatibility**: Safe created using v1.3.0 and above are compatible with this method. Safes created from mastercopies v1.0.0, v1.1.1, and v1.2.0 will not be able to use this method.
+
+## Considerations
+
+When deploying a Safe on multiple chains, there are several important considerations to keep in mind:
+
+- **Identical Configuration**: The Safe deployed on other chains will have an identical configuration, such as owners, threshold, modules, etc., as the Safe on the original chain during deployment. Therefore, to access the Safe on the new chain, the private keys of the other owners should be available.
+- **Security**: It is not recommended to use this method if the private keys of the initial owners are compromised.
+- **Version Consistency**: The version of the Safe singleton contract cannot be updated while replaying the deployment on other chains.
+
+## References
+
+For more detailed information, refer to the following resources:
+
+- [Deploying a Multi-Chain Safe](https://help.safe.global/en/articles/222612-deploying-a-multi-chain-safe)
+
+By following these guidelines and considerations, users can effectively deploy and manage Safe accounts across multiple chains.


### PR DESCRIPTION
Changes in PR:

- Create a page on multichain deployment
- Mention how do deploy Safe on multiple chains at Same address: Reference Protocol Kit, Wallet UI, and help page

The page gives info on what factors address of Safe depends and avoid repeating the information already available across different articles.