### PR TITLE
Fix deployment script to S3

### DIFF
--- a/.github/scripts/s3_upload.sh
+++ b/.github/scripts/s3_upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ev
+set -e
 
 aws s3 sync ./out $BUCKET --delete
 

--- a/.github/scripts/s3_upload.sh
+++ b/.github/scripts/s3_upload.sh
@@ -8,8 +8,4 @@ aws s3 sync ./out $BUCKET --delete
 
 cd out
 
-for file in $(find . -name '*.html' | sed 's|^\./||'); do
-    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html' &
-done
-
-wait
+find . -name '*.html' | sed 's|^\./||' | parallel -j 10 aws s3 cp {} $BUCKET/{/..} --content-type 'text/html'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -36,6 +36,7 @@ jobs:
           NEXT_PUBLIC_IS_PRODUCTION: true
           NEXT_PUBLIC_N8N_WEBHOOK_URL: ${{ secrets.NEXT_PUBLIC_N8N_WEBHOOK_URL }}
           NEXT_PUBLIC_HOST_URL: 'https://docs.safe.global'
+          NODE_OPTIONS: "--max-old-space-size=8000"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
         run: pnpm build
         env:
           NEXT_PUBLIC_HOST_URL: 'https://docs.staging.5afe.dev'
+          NODE_OPTIONS: "--max-old-space-size=8000"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:
           message-id: praul
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: |
             ## Branch preview
             ✅ Deployed successfully in branch deployment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
             ## Branch preview
             ⏳ Deploying a preview site...
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Uploading the build output to AWS S3 bucket fails after the app reached a certain size. This PR solved this by changing the `s3_upload.sh` script, replacing a `for` loop with `parallel` to limit to 10 the number of parallel threads being to upload files.