### PR TITLE
fix(API): correct curl sample requests

### DIFF
--- a/.github/scripts/generateApiReference.ts
+++ b/.github/scripts/generateApiReference.ts
@@ -6,7 +6,7 @@ const pathsMetadata = require('../../components/ApiReference/paths-metadata.json
 const txServiceNetworks = require('../../components/ApiReference/tx-service-networks.json')
 
 const curlify = (req: any) =>
-  `curl -X ${req.method} https://safe-transaction-${req.networkName}.safe.global/api${
+  `curl -X ${req.method} https://safe-transaction-${req.networkName}.safe.global${
     req.url
   } \\
     -H "Accept: application/json" \\


### PR DESCRIPTION
## What it solves

curl sample requests in the docs wrongly have /api/api/v... instead of /api/v...

this can be seen on for example https://docs.safe.global/core-api/transaction-service-reference/mainnet#List-Multisig-Confirmations

Example:
curl -X GET https://safe-transaction-mainnet.safe.global/api/api/v1/contracts/ \
    -H "Accept: application/json" \
    -H "content-type: application/json" \

There's not much documententation about safe-docs and how al of these are generated, but this struck me as a likely fix.


## Changelog

- Fix curl api samples generation

## Checklist

- [x] I've followed all `safe-docs` [pull request rules](https://safe-global.notion.site/safe-docs-pr-rules)
