### PR TITLE
Add name reporting to resource check and tweak one resource name

### DIFF
--- a/.github/scripts/validateResources.js
+++ b/.github/scripts/validateResources.js
@@ -6,31 +6,31 @@ const communityResourcesPath =
 
 const validateResource = (resource, index, resources) => {
   if (resources.findIndex(r => r.url === resource.url) !== index) {
-    console.log(`Duplicate resource`)
+    console.log(`${resource.name}: Duplicate resource`)
     return false
   }
   if (!resource.name) {
-    console.log(`Resource name is missing`)
+    console.log(`${resource.name}: Resource name is missing`)
     return false
   }
   if (!resource.type) {
-    console.log(`Resource type is missing`)
+    console.log(`${resource.name}: Resource type is missing`)
     return false
   }
   if (!resource.date) {
-    console.log(`Resource date is missing`)
+    console.log(`${resource.name}: Resource date is missing`)
     return false
   }
   if (!resource.description) {
-    console.log(`Resource description is missing`)
+    console.log(`${resource.name}: Resource description is missing`)
     return false
   }
   if (resource.description.length > 200) {
-    console.log(`Resource description is too long`)
+    console.log(`${resource.name}: Resource description is too long`)
     return false
   }
   if (!resource.tags || !resource.tags.length) {
-    console.log(errorMessage + `Resource tags are missing`)
+    console.log(errorMessage + `${resource.name}: Resource tags are missing`)
     return false
   }
   if (
@@ -38,11 +38,11 @@ const validateResource = (resource, index, resources) => {
     (!resource.url.startsWith('https://www.youtube.com/watch?v=') ||
       resource.url.length !== 43)
   ) {
-    console.log(`Invalid YouTube URL`)
+    console.log(`${resource.name}: Invalid YouTube URL`)
     return false
   }
   if (!resource.lastChecked) {
-    console.log(`The last checked property is missing. If adding a new resource, please add today's date`)
+    console.log(`${resource.name}: The last checked property is missing. If adding a new resource, please add today's date`)
     return false
   }
   return true

--- a/components/ResourceHub/company-resources.json
+++ b/components/ResourceHub/company-resources.json
@@ -167,7 +167,7 @@
     "url": "https://www.youtube.com/watch?v=F1VcGfTkIOk",
     "type": "Video",
     "date": "2024-12-12",
-    "description": "In this Webinar, Safe developers Akshay and Germán talk about the EIP-7702 demo. With this demo you can already try out, how to convert an EOA into a Smart Account and send a sponsored batched transaction.",
+    "description": "In this Webinar, Safe developers Akshay and Germán talk about the EIP-7702 demo. It shows how to convert an EOA into a Smart Account and send a sponsored batched transaction.",
     "tags": [
       "Tutorial",
       "Safe Smart Account",


### PR DESCRIPTION
## What it solves

Before, the resource validation was not reporting the name of the resource that produced an error. This error is now printed to console. 

Also, an erroreneous resource is tweaked. The description is shortened to under 200 characters.
