### PR TITLE
fix: Wrong link not pointing to allowances module

### DIFF
--- a/pages/advanced/smart-account-overview.mdx
+++ b/pages/advanced/smart-account-overview.mdx
@@ -88,7 +88,7 @@ One core feature of a Safe account is that it can be operated by multiple accoun
 Modules add additional functionalities to the Safe accounts. They are smart contracts that implement Safe's functionality while separating module logic from Safe's core contract. Depending on the use case, modules could, for instance, allow the execution of transactions without requiring all confirmations. A basic Safe does not require any modules. Adding and removing a module requires confirmation from the required threshold of owners. Modules are very security-critical, so they need to be as secure as all other Safe contracts.
 
 Some of the available modules are:
-- [Allowance Module](https://github.com/safe-global/safe-modules/tree/main/modules/4337)
+- [Allowance Module](https://github.com/safe-global/safe-modules/tree/main/modules/allowances)
 - [Recovery Module](https://github.com/safe-global/safe-modules/tree/main/modules/recovery)
 - [4337 Module](https://github.com/safe-global/safe-modules/tree/main/modules/4337)
 - [Passkey Module](https://github.com/safe-global/safe-modules/tree/main/modules/passkey)


### PR DESCRIPTION
## What it solves

It fixes the wrong link on one of the pages. 
It pointed to `4337` module, but it should point to the `allowances` module.

## Changelog

-


## Checklist

- [x] I've followed all `safe-docs` [pull request rules](https://safe-global.notion.site/safe-docs-pr-rules)
