### PR TITLE
Add Contact for Wallet Submissions

### DIFF
--- a/pages/advanced/smart-account-bug-bounty.md
+++ b/pages/advanced/smart-account-bug-bounty.md
@@ -1,8 +1,8 @@
 # Bug Bounty
 
-Participate in the Safe Bug Bounty program to find bugs and get rewards. Earn up to $1,000,000 for every bug you report. Please carefully read through the [submission process](#submission-process) section and get in touch via [bounty@safe.global](mailto:bounty@safe.global). You can also review the [bug bounties](./smart-account-bug-bounty/past-paid-bounties.md) we have paid in the past.
-
 > Note that this bug bounty program **only applies to smart contract related vulnerabilities and bugs**. For other kinds of submissions, please contact [wallet-reports@safe.global](mailto:wallet-reports@safe.global).
+
+Participate in the Safe Bug Bounty program to find bugs and get rewards. Earn up to $1,000,000 for every bug you report. Please carefully read through the [submission process](#submission-process) section and get in touch via [bounty@safe.global](mailto:bounty@safe.global). You can also review the [bug bounties](./smart-account-bug-bounty/past-paid-bounties.md) we have paid in the past.
 
 ## Audits
 

--- a/pages/advanced/smart-account-bug-bounty.md
+++ b/pages/advanced/smart-account-bug-bounty.md
@@ -2,6 +2,8 @@
 
 Participate in the Safe Bug Bounty program to find bugs and get rewards. Earn up to $1,000,000 for every bug you report. Please carefully read through the [submission process](#submission-process) section and get in touch via [bounty@safe.global](mailto:bounty@safe.global). You can also review the [bug bounties](./smart-account-bug-bounty/past-paid-bounties.md) we have paid in the past.
 
+> Note that this bug bounty program **only applies to smart contract related vulnerabilities and bugs**. For other kinds of submissions, please contact [wallet-reports@safe.global](mailto:wallet-reports@safe.global).
+
 ## Audits
 
 Smart contract security experts have carefully audited Safe's contracts. Please refer to the [security audits page](./smart-account-audits.md) for details.


### PR DESCRIPTION
## Changelog

- Add a callout explaining that `bounty@safe.global` is only for smart contract related submissions, and other kinds of submissions should go to the `wallet-reports@safe.global`

## Checklist

- [ ] I've followed all `safe-docs` [pull request rules](https://safe-global.notion.site/safe-docs-pr-rules)
  - Like in #759 :shrug:
