### PR TITLE
Remove package.json bump from release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,11 +16,6 @@ on:
         description: 'Exact tag version (overrides bump_type, e.g. v1.2.3)'
         required: false
         type: string
-      bump_package_json:
-        description: 'Update version in package.json'
-        required: false
-        type: boolean
-        default: true
 
 jobs:
   create-release:
@@ -114,20 +109,6 @@ jobs:
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Bump package.json version
-        if: inputs.bump_package_json
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${TAG#v}"
-          npm version "$VERSION" --no-git-tag-version
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "Set release version to $TAG"
-          git push
 
       - name: Create GitHub Release
         id: create


### PR DESCRIPTION
## What

Removes the `Bump package.json version` step (and its `bump_package_json` input) from `create-release.yml`. The step committed and pushed directly to the default branch, which the new ruleset rejects: PR-only changes, verified signatures, committer-email allow-list, and required CodeQL scanning all fail on a direct push.

## Why this is safe

Nothing reads `package.json`'s `version`:
- No `npm_package_version` usage, no `package.json` import, no workflow/script lookup.
- `deploy-release.yml` keys entirely off the git tag (`github.event.release.tag_name`); `pnpm build` doesn't embed the version.
- The only `.version` references in source are unrelated smart-account contract versions.

The git tag remains the source of truth for the release version. The release is still created at HEAD with the GitHub App token, so `deploy-release.yml` (`on: release: published`) still triggers.

## Effect

`package.json` version stays pinned. If it ever needs updating, bump it in a normal PR.
