### PR TITLE
docs(rpc-requirements): add third-party benchmark reference for RPC Provider expectations

### DIFF
--- a/pages/core-api/api-safe-transaction-service/rpc-requirements.md
+++ b/pages/core-api/api-safe-transaction-service/rpc-requirements.md
@@ -53,3 +53,7 @@ For RPC providers, we expect communication on every update and configuration cha
 - **Number of** **batch requests** allowed in the same HTTP request.
 - **Block range** that can be queried in queries like **eth_getLogs** or **trace_filter**.
 - **Results limit for endpoints** (for example, some providers implement a limit to the number of queries like **eth_getLogs**). The indexer expects failures and not capped results.
+
+## Comparing providers against these expectations
+
+Independent third-party measurements of public RPC providers on the chains the Transaction Service supports (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle and more) are published continuously at [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities). Latency (p50/p95/p99), reliability classification (HTTP errors vs JSON-RPC error responses), and stale-block detection are probed every minute from three regions under a CC BY 4.0 license, with the harness open sourced on GitHub. OpenChainBench has no affiliation with any RPC provider, so operators evaluating providers against the expectations above can use it as a neutral reference point.


### PR DESCRIPTION
## Summary

Adds one `Comparing providers against these expectations` subsection at the end of `pages/core-api/api-safe-transaction-service/rpc-requirements.md`, pointing Transaction Service operators to an independent third-party benchmark that measures the exact criteria the `RPC Provider expectations` list already covers.

## Why this specific placement

The existing `RPC Provider expectations` section lists four things operators should care about when evaluating an RPC:

1. Timeout for the requests
2. Number of batch requests allowed in the same HTTP request
3. Block range that can be queried in `eth_getLogs` / `trace_filter`
4. Results limit for endpoints

The page tells operators what to look for, but not where to find neutral data to compare providers against those criteria. Every operator running the Transaction Service today has to figure this out on their own.

## What the referenced resource does

[OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) publishes continuous measurements of exactly these criteria for public RPC providers across the chains the Transaction Service supports (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle and more):

- p50/p95/p99 latency (Timeout expectation)
- HTTP error vs JSON-RPC `error` field classification (the "expects failures not capped results" expectation)
- Stale-block detection (relevant to indexer freshness)

Measurements are probed every minute from three regions (US East, EU West, Singapore). Data ships under CC BY 4.0, harness is open source Go on GitHub, methodology public. OpenChainBench has no affiliation with any RPC provider or chain foundation.

## Change

One subsection appended at the end of the file. No changes to any existing section, no changes to code samples, no changes to other pages.

## Disclosure

I maintain OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.