### PR TITLE
docs: deprecate relaying via Gelato

### DIFF
--- a/pages/home/glossary.md
+++ b/pages/home/glossary.md
@@ -123,7 +123,8 @@ See also:
 A relayer is a third-party service acting as an intermediary between users' accounts and [blockchain networks](#network). It executes transactions on behalf of users and covers the associated execution costs, which may or may not be claimed.
 
 See also:
-- [What's Relaying?](https://docs.gelato.network/developer-services/relay/what-is-relaying) on docs.gelato.network
+- [Bundlers](https://docs.erc4337.io/bundlers) on erc4337.io
+- [Relay Kit documentation](../sdk/relay-kit.mdx) on docs.safe.global
 
 ## Safe{DAO}
 

--- a/pages/sdk/overview.mdx
+++ b/pages/sdk/overview.mdx
@@ -63,14 +63,14 @@ The [API Kit](./api-kit.mdx) helps interact with the Safe Transaction Service AP
 The [Relay Kit](./relay-kit.mdx) enables transaction relaying with Safe and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or get their transactions sponsored.
 
 - Use ERC-4337 with Safe
-- Gas-less experiences using Gelato
+- Gas-less experiences
 - Sponsored transaction
 - Pay fees in ERC-20 tokens
 
 <Grid container mt={3}>
   <CustomCard
     title={'Relay Kit'}
-    description={'Learn about the Relay Kit and the packs integrating ERC-4337 and Gelato.'}
+    description={'Learn about the Relay Kit and the pack integrating ERC-4337.'}
     url={'./relay-kit'}
     newTab={false}
   />

--- a/pages/sdk/relay-kit.mdx
+++ b/pages/sdk/relay-kit.mdx
@@ -1,9 +1,14 @@
 import { Grid } from '@mui/material'
+import { Callout } from 'nextra/components'
 import CustomCard from '../../components/CustomCard'
 
 # Relay Kit
 
 The Relay Kit enables transaction relaying with Safe, and allows users to pay for the transaction fees from their Safe account using the blockchain native token, ERC-20 tokens, or to get their transactions sponsored.
+
+<Callout type="warning">
+  Relaying transactions through Gelato isn't supported from September 1, 2026. Use the [ERC-4337 Safe accounts guide](./relay-kit/guides/4337-safe-sdk.mdx) instead. See the [Gelato Relay guide](./relay-kit/guides/gelato-relay.mdx) for migration details.
+</Callout>
 
 <Grid item mt={3}>
   <CustomCard
@@ -15,7 +20,7 @@ The Relay Kit enables transaction relaying with Safe, and allows users to pay fo
 
 The following guides show how to use the Relay Kit and integrate it into your project by using one of the packs:
 - [Integrate ERC-4337 Safe accounts](./relay-kit/guides/4337-safe-sdk.mdx)
-- [Integrate Gelato Relay](./relay-kit/guides/gelato-relay.mdx)
+- [Integrate Gelato Relay](./relay-kit/guides/gelato-relay.mdx) (deprecated)
 
 ## Resources
 

--- a/pages/sdk/relay-kit/guides/_meta.json
+++ b/pages/sdk/relay-kit/guides/_meta.json
@@ -1,6 +1,6 @@
 {
   "4337-safe-sdk": "ERC-4337 Safe SDK",
-  "gelato-relay": "Gelato Relay",
+  "gelato-relay": "Gelato Relay (deprecated)",
   "migrate-to-v2": "Migrate to v2",
   "migrate-to-v3": "Migrate to v3"
 }

--- a/pages/sdk/relay-kit/guides/gelato-relay.mdx
+++ b/pages/sdk/relay-kit/guides/gelato-relay.mdx
@@ -1,199 +1,47 @@
-import { Steps } from 'nextra/components'
+import { Callout } from 'nextra/components'
 
-# Integration with Gelato
+# Integration with Gelato (deprecated)
 
-The [Gelato relay](https://docs.gelato.network/developer-services/relay) allows developers to execute gasless transactions.
+<Callout type="error" emoji="⚠️">
+  **Relaying transactions through Gelato is no longer supported.**
 
-## Prerequisites
+  From **September 1, 2026**, transactions can't be relayed through Gelato using
+  the Relay Kit. This affects the `GelatoRelayPack`, including both the Gelato
+  1Balance and the Gelato SyncFee flows.
 
-1. [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm).
-2. Have a Safe account configured with threshold equal to 1, where only one signature is needed to execute transactions.
-3. To use Gelato 1Balance an [API key](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance) is required.
+  If your integration relies on the `GelatoRelayPack`, migrate to the
+  [ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx), which uses the `Safe4337Pack`
+  to sponsor transactions or pay fees in ERC-20 tokens through a paymaster.
+</Callout>
 
-## Install dependencies
+## What changed
 
-```bash
-yarn add ethers @safe-global/relay-kit @safe-global/protocol-kit @safe-global/types-kit
-```
+The Relay Kit previously shipped two ways to relay a Safe transaction through
+Gelato:
 
-## Relay Kit options
+- **Gelato 1Balance**, which sponsored transactions from a prepaid deposit.
+- **Gelato SyncFee**, which paid the gas fees directly with funds held in the
+  Safe account.
 
-Currently, the Relay Kit is only compatible with the [Gelato relay](https://docs.gelato.network/developer-services/relay). The Gelato relay can be used in two ways:
-1. [Gelato 1Balance](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance)
-2. [Gelato SyncFee](https://docs.gelato.network/developer-services/relay/quick-start/callwithsyncfee)
+Neither flow is supported anymore. The code examples previously published on
+this page have been removed so they aren't copied into new integrations.
 
-## Gelato 1Balance
+## What to use instead
 
-[Gelato 1Balance](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance) allows you to execute transactions using a prepaid deposit. This can be used to sponsor transactions to other Safes or even to use a deposit on Polygon to pay the fees for a wallet on another chain.
+The [`Safe4337Pack`](./4337-safe-sdk.mdx) covers the same use cases through the
+ERC-4337 standard:
 
-For the 1Balance quickstart tutorial, you will use the Gelato relayer to pay for the gas fees on BNB Chain using the Polygon USDC you have deposited into your Gelato 1Balance account.
+| Previous Gelato flow | ERC-4337 equivalent |
+| --- | --- |
+| 1Balance (sponsored transactions) | A verifying paymaster configured with `paymasterOptions` |
+| SyncFee (pay fees from the Safe balance) | An ERC-20 paymaster configured with `paymasterOptions` |
 
-<Steps>
+See the [ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx) for a complete example,
+and the [`Safe4337Pack` reference](../reference/safe-4337-pack.mdx) for the full
+API.
 
-  ### Setup
+## Resources
 
-  1. Start with a [1/1 Safe on BNB Chain](https://app.safe.global/transactions/history?safe=bnb:0x6651FD6Abe0843f7B6CB9047b89655cc7Aa78221).
-  2. [Deposit Polygon USDC into Gelato 1Balance](https://docs.gelato.network/developer-services/relay/payment-and-fees/.1balance#how-can-i-use-1balance) ([transaction 0xa5f38](https://polygonscan.com/tx/0xa5f388c2d6e0d1bb32e940fccddf8eab182ad191644936665a54bf4bb1bac555)).
-  3. The Safe owner [0x6Dbd26Bca846BDa60A90890cfeF8fB47E7d0f22c](https://bscscan.com/address/0x6Dbd26Bca846BDa60A90890cfeF8fB47E7d0f22c) signs a transaction to send 0.0005 BNB and submits it to Gelato relay.
-  4. [Track the relay request](https://docs.gelato.network/developer-services/relay/quick-start/tracking-your-relay-request) of [Gelato Task ID 0x1bf7](https://relay.gelato.digital/tasks/status/0x1bf7664a1e176472f604bb3840d3d2a5bf56f98b60307961c3f8cee099f1eeb8).
-  5. [Transaction 0x814d3](https://bscscan.com/tx/0x814d385c0ec036be65663b5fbfb0d8d4e0d35af395d4d96b13f2cafaf43138f9) is executed on the blockchain.
-
-  ### Use a Safe as the Relay
-
-  While using Gelato, you can specify that you only want the relay to allow transactions from specific smart contracts. If one of those smart contracts is a Safe smart contract, you will need to either verify the contract on a block explorer or get the ABI of the contract implementation (not the ABI of the smart contract address). This is because the Safe smart contracts use the [Proxy Pattern](https://medium.com/coinmonks/proxy-pattern-and-upgradeable-smart-contracts-45d68d6f15da), so the implementation logic for your smart contract exists on a different address.
-
-  ### Imports
-
-  ```typescript
-  import { ethers } from 'ethers'
-  import { GelatoRelayPack } from '@safe-global/relay-kit'
-  import Safe from '@safe-global/protocol-kit'
-  import {
-    MetaTransactionData,
-    MetaTransactionOptions
-  } from '@safe-global/types-kit'
-  ```
-
-  ### Initialize the transaction settings
-
-  Modify the variables to customize to match your desired transaction settings.
-
-  ```typescript
-  // https://chainlist.org
-  const RPC_URL = 'https://endpoints.omniatech.io/v1/bsc/mainnet/public'
-  const OWNER_PRIVATE_KEY = process.env.OWNER_PRIVATE_KEY
-  const safeAddress = '0x...' // Safe from which the transaction will be sent
-
-  // Any address can be used for destination. In this example, we use vitalik.eth
-  const destinationAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
-  const withdrawAmount = ethers.parseUnits('0.005', 'ether').toString()
-  ```
-
-  ### Create a transaction
-
-  ```typescript
-  // Create a transactions array with one transaction object
-  const transactions: MetaTransactionData[] = [{
-    to: destinationAddress,
-    data: '0x',
-    value: withdrawAmount
-  }]
-
-  const options: MetaTransactionOptions = {
-    isSponsored: true
-  }
-  ```
-
-  ### Instantiate the Protocol Kit and Relay Kit
-
-  ```typescript
-  const protocolKit = await Safe.init({
-    provider: RPC_URL,
-    signer: OWNER_PRIVATE_KEY,
-    safeAddress
-  })
-
-  const relayKit = new GelatoRelayPack({
-    apiKey: process.env.GELATO_RELAY_API_KEY!,
-    protocolKit
-  })
-  ```
-
-  ### Prepare the transaction
-
-  ```typescript
-  const safeTransaction = await relayKit.createTransaction({
-    transactions,
-    options
-  })
-
-  const signedSafeTransaction = await protocolKit.signTransaction(safeTransaction)
-  ```
-
-  ### Send the transaction to the relay
-
-  ```typescript
-  const response = await relayKit.executeTransaction({
-    executable: signedSafeTransaction,
-    options
-  })
-
-  console.log(`Relay Transaction Task ID: https://relay.gelato.digital/tasks/status/${response.taskId}`)
-  ```
-
-</Steps>
-
-## Gelato SyncFee
-
-[Gelato SyncFee](https://docs.gelato.network/developer-services/relay/quick-start/callwithsyncfee) allows you to execute a transaction and pay the gas fees directly with funds in your Safe, even if you don't have ETH or the native blockchain token.
-
-For the SyncFee quickstart tutorial, you will use the Gelato relayer to pay for the gas fees on the BNB Chain using the BNB you hold in your Safe. No need to have funds on your signer.
-
-<Steps>
-
-  ### Imports
-
-  ```typescript
-  import { ethers } from 'ethers'
-  import { GelatoRelayPack } from '@safe-global/relay-kit'
-  import Safe from '@safe-global/protocol-kit'
-  import { MetaTransactionData } from '@safe-global/types-kit'
-  ```
-
-  ### Initialize the transaction settings
-
-  Modify the variables to customize to match your desired transaction settings.
-
-  ```typescript
-  // https://chainlist.org
-  const RPC_URL = 'https://endpoints.omniatech.io/v1/bsc/mainnet/public'
-  const OWNER_PRIVATE_KEY = process.env.OWNER_PRIVATE_KEY
-  const safeAddress = '0x...' // Safe from which the transaction will be sent
-
-  // Any address can be used for destination. In this example, we use vitalik.eth
-  const destinationAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
-  const withdrawAmount = ethers.parseUnits('0.005', 'ether').toString()
-  ```
-
-  ### Create a transaction
-
-  ```typescript
-  // Create a transactions array with one transaction object
-  const transactions: MetaTransactionData[] = [{
-    to: destinationAddress,
-    data: '0x',
-    value: withdrawAmount
-  }]
-  ```
-
-  ### Instantiate the Protocol Kit and Relay Kit
-
-  ```typescript
-  const protocolKit = await Safe.init({
-    provider: RPC_URL,
-    signer: OWNER_PRIVATE_KEY,
-    safeAddress
-  })
-
-  const relayKit = new GelatoRelayPack({ protocolKit })
-  ```
-
-  ### Prepare the transaction
-
-  ```typescript
-  const safeTransaction = await relayKit.createTransaction({ transactions })
-
-  const signedSafeTransaction = await protocolKit.signTransaction(safeTransaction)
-  ```
-
-  ### Send the transaction to the relay
-
-  ```typescript
-  const response = await relayKit.executeTransaction({
-    executable: signedSafeTransaction  
-  })
-
-  console.log(`Relay Transaction Task ID: https://relay.gelato.digital/tasks/status/${response.taskId}`)
-  ```
-
-</Steps>
+- [ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx)
+- [Safe4337Pack reference](../reference/safe-4337-pack.mdx)
+- [Relay Kit on GitHub](https://github.com/safe-global/safe-core-sdk/tree/main/packages/relay-kit)

--- a/pages/sdk/relay-kit/guides/gelato-relay.mdx
+++ b/pages/sdk/relay-kit/guides/gelato-relay.mdx
@@ -5,13 +5,14 @@ import { Callout } from 'nextra/components'
 <Callout type="error" emoji="⚠️">
   **Relaying transactions through Gelato is no longer supported.**
 
-  From **September 1, 2026**, transactions can't be relayed through Gelato using
-  the Relay Kit. This affects the `GelatoRelayPack`, including both the Gelato
-  1Balance and the Gelato SyncFee flows.
+From **September 1, 2026**, transactions can't be relayed through Gelato using
+the Relay Kit. This affects the `GelatoRelayPack`, including both the Gelato
+1Balance and the Gelato SyncFee flows.
 
-  If your integration relies on the `GelatoRelayPack`, migrate to the
-  [ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx), which uses the `Safe4337Pack`
-  to sponsor transactions or pay fees in ERC-20 tokens through a paymaster.
+If your integration relies on the `GelatoRelayPack`, migrate to the
+[ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx), which uses the `Safe4337Pack`
+to sponsor transactions or pay fees in ERC-20 tokens through a paymaster.
+
 </Callout>
 
 ## What changed
@@ -31,14 +32,31 @@ this page have been removed so they aren't copied into new integrations.
 The [`Safe4337Pack`](./4337-safe-sdk.mdx) covers the same use cases through the
 ERC-4337 standard:
 
-| Previous Gelato flow | ERC-4337 equivalent |
-| --- | --- |
-| 1Balance (sponsored transactions) | A verifying paymaster configured with `paymasterOptions` |
-| SyncFee (pay fees from the Safe balance) | An ERC-20 paymaster configured with `paymasterOptions` |
+| Previous Gelato flow                     | ERC-4337 equivalent                                      |
+| ---------------------------------------- | -------------------------------------------------------- |
+| 1Balance (sponsored transactions)        | A verifying paymaster configured with `paymasterOptions` |
+| SyncFee (pay fees from the Safe balance) | An ERC-20 paymaster configured with `paymasterOptions`   |
 
 See the [ERC-4337 Safe SDK guide](./4337-safe-sdk.mdx) for a complete example,
 and the [`Safe4337Pack` reference](../reference/safe-4337-pack.mdx) for the full
 API.
+
+### Differences
+
+The ERC-4337 flow covers the same use cases, but is not a drop-in substitute. 
+Before you start rewriting note these differences:
+
+- **No cross-chain sponsoring:** With the Gelato flow you could sponsor 
+  cross-chain, using a deposit on one chain sponsoring a transaction on 
+  another. This feature is not available on the ERC-4337 flow. You have 
+  to fund the paymaster per chain.
+- **Chain Availability:** The ERC-4337 module is deployed on a different 
+  chainset than the previous flow. On chains where it is not deployed, 
+  `init()` will throw. The 
+  [official module deployments](https://github.com/safe-global/safe-modules-deployments/tree/main/src/assets/safe-4337-module) 
+  lists the chains where it is deplyoed.
+- **Safe ≥ v1.4.1:** The ERC-4337 flow is supported from Safe v1.4.1 
+  onwards.
 
 ## Resources
 

--- a/pages/sdk/relay-kit/guides/gelato-relay.mdx
+++ b/pages/sdk/relay-kit/guides/gelato-relay.mdx
@@ -51,12 +51,12 @@ Before you start rewriting note these differences:
   another. This feature is not available on the ERC-4337 flow. You have 
   to fund the paymaster per chain.
 - **Chain Availability:** The ERC-4337 module is deployed on a different 
-  chainset than the previous flow. On chains where it is not deployed, 
+  chain set than the previous flow. On chains where it is not deployed, 
   `init()` will throw. The 
   [official module deployments](https://github.com/safe-global/safe-modules-deployments/tree/main/src/assets/safe-4337-module) 
-  lists the chains where it is deplyoed.
-- **Safe ≥ v1.4.1:** The ERC-4337 flow is supported from Safe v1.4.1 
-  onwards.
+  lists the chains where it is deployed.
+- **Safe ≥ v1.4.1:** The ERC-4337 flow is supported for Safe v1.4.1 
+  and higher.
 
 ## Resources
 

--- a/public/llms-ctx-full.txt
+++ b/public/llms-ctx-full.txt
@@ -290,26 +290,38 @@ const pendingTxs = await safeService.getPendingTransactions('0x...')
 
 ### Relay Kit Example
 
-The Relay Kit enables gas-free transactions:
+The Relay Kit enables gas-free transactions through ERC-4337. Relaying through
+Gelato and the `GelatoRelayPack` are deprecated and unsupported from September
+1, 2026 — use the `Safe4337Pack` instead.
 
 ```typescript
-import { GelatoRelayPack } from '@safe-global/relay-kit'
+import { Safe4337Pack } from '@safe-global/relay-kit'
 
-// Create a relay pack
-const relayPack = new GelatoRelayPack('your-gelato-api-key')
+// Create the pack, optionally with a paymaster to sponsor the fees
+const safe4337Pack = await Safe4337Pack.init({
+  provider: RPC_URL,
+  signer: SIGNER_PRIVATE_KEY,
+  bundlerUrl: BUNDLER_URL,
+  options: {
+    safeAddress: '0x...'
+  },
+  paymasterOptions: {
+    isSponsored: true,
+    paymasterUrl: PAYMASTER_URL,
+    paymasterAddress: '0x...'
+  }
+})
 
-// Create a transaction
-const safeTransactionData = {
-  to: '0x...',
-  value: '0',
-  data: '0x...'
-}
+// Create a user operation from one or more transactions
+const safeOperation = await safe4337Pack.createTransaction({
+  transactions: [{ to: '0x...', value: '0', data: '0x...' }]
+})
 
-// Relay the transaction (user doesn't pay gas)
-const response = await relayPack.relayTransaction({
-  target: safeAddress,
-  encodedTransaction: encodedTx,
-  chainId: 11155111
+// Sign it and submit it to the bundler (user doesn't pay gas)
+const signedSafeOperation = await safe4337Pack.signSafeOperation(safeOperation)
+
+const userOperationHash = await safe4337Pack.executeTransaction({
+  executable: signedSafeOperation
 })
 ```
 

--- a/public/llms-ctx.txt
+++ b/public/llms-ctx.txt
@@ -290,26 +290,38 @@ const pendingTxs = await safeService.getPendingTransactions('0x...')
 
 ### Relay Kit Example
 
-The Relay Kit enables gas-free transactions:
+The Relay Kit enables gas-free transactions through ERC-4337. Relaying through
+Gelato and the `GelatoRelayPack` are deprecated and unsupported from September
+1, 2026 — use the `Safe4337Pack` instead.
 
 ```typescript
-import { GelatoRelayPack } from '@safe-global/relay-kit'
+import { Safe4337Pack } from '@safe-global/relay-kit'
 
-// Create a relay pack
-const relayPack = new GelatoRelayPack('your-gelato-api-key')
+// Create the pack, optionally with a paymaster to sponsor the fees
+const safe4337Pack = await Safe4337Pack.init({
+  provider: RPC_URL,
+  signer: SIGNER_PRIVATE_KEY,
+  bundlerUrl: BUNDLER_URL,
+  options: {
+    safeAddress: '0x...'
+  },
+  paymasterOptions: {
+    isSponsored: true,
+    paymasterUrl: PAYMASTER_URL,
+    paymasterAddress: '0x...'
+  }
+})
 
-// Create a transaction
-const safeTransactionData = {
-  to: '0x...',
-  value: '0',
-  data: '0x...'
-}
+// Create a user operation from one or more transactions
+const safeOperation = await safe4337Pack.createTransaction({
+  transactions: [{ to: '0x...', value: '0', data: '0x...' }]
+})
 
-// Relay the transaction (user doesn't pay gas)
-const response = await relayPack.relayTransaction({
-  target: safeAddress,
-  encodedTransaction: encodedTx,
-  chainId: 11155111
+// Sign it and submit it to the bundler (user doesn't pay gas)
+const signedSafeOperation = await safe4337Pack.signSafeOperation(safeOperation)
+
+const userOperationHash = await safe4337Pack.executeTransaction({
+  executable: signedSafeOperation
 })
 ```
 


### PR DESCRIPTION
Relaying transactions through Gelato is unavailable from September 1, 2026.

- Replace the Gelato Relay guide body with a deprecation notice and a migration table pointing to the Safe4337Pack. The page and its two inbound redirects stay live.
- Mark the guide as deprecated in the sidebar and on the Relay Kit landing page.
- Drop Gelato from the SDK overview bullet list and Relay Kit card.
- Replace the Gelato reference in the "Relayer" glossary entry.
- Replace the GelatoRelayPack snippet in llms-ctx.txt and llms-ctx-full.txt with a Safe4337Pack example. The old snippet also used a pre-v2 API that no longer matched the SDK.

The migrate-to-v2 guide keeps its GelatoRelayPack section as a historical migration record.

## What it solves

Resolves #

## Changelog

- 

## Checklist

- [x] I've followed all `safe-docs` [pull request rules](https://safe-global.notion.site/safe-docs-pr-rules)
